### PR TITLE
feat: documents

### DIFF
--- a/src/app/zaken/templates/zaak.mustache
+++ b/src/app/zaken/templates/zaak.mustache
@@ -40,6 +40,15 @@
                     </li>
                 {{/status_list}}
                 </ol>
+
+                <h2>Documenten</h2>
+                {{#documenten}}
+                    <ul>
+                        <li><a href="{{url}}">{{titel}}</a></li>
+                {{/documenten}}
+                {{^documenten}}
+                <p>Er zijn geen documenten bij deze zaak te tonen.
+                {{/documenten}}
             {{/zaak}}
             {{^zaak}}
                 <h1>Geen zaak gevonden</h1>

--- a/src/app/zaken/tests/Documenten.test.ts
+++ b/src/app/zaken/tests/Documenten.test.ts
@@ -1,0 +1,92 @@
+import { Bsn } from '@gemeentenijmegen/utils';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import zaak1 from './samples/zaak1.json';
+import catalogi from './samples/catalogi.json';
+import resultaattypen from './samples/resultaattypen.json';
+import resultaatvoorbeeld from './samples/resultaatvoorbeeld.json';
+import rol from './samples/rol.json';
+import statustypen from './samples/statustypen.json';
+import statusvoorbeeld from './samples/statusvoorbeeld.json';
+import statusvoorbeeld2 from './samples/statusvoorbeeld2.json';
+import zaak1noStatus from './samples/zaak1noStatus.json';
+import zaaktypen from './samples/zaaktypen.json';
+import zaakinformatieobjecten from './samples/zaakinformatieobjecten.json';
+import enkelvoudiginformatiobject from './samples/enkelvoudiginformatieobject.json';
+import { OpenZaakClient } from '../OpenZaakClient';
+import { Zaken } from '../Zaken';
+
+let baseUrl = new URL('http://localhost');
+if (process.env.VIP_BASE_URL) {
+  baseUrl = new URL(process.env.VIP_BASE_URL);
+}
+const axiosMock = new MockAdapter(axios);
+
+beforeAll(() => {
+  axiosMock.onGet('/catalogi/api/v1/zaaktypen').reply(200, zaaktypen);
+  axiosMock.onGet('/catalogi/api/v1/statustypen').reply(200, statustypen);
+  axiosMock.onGet('/catalogi/api/v1/resultaattypen').reply(200, resultaattypen);
+  axiosMock.onGet('/catalogi/api/v1/catalogussen').reply(200, catalogi);
+  axiosMock.onGet('/zaken/api/v1/zaken/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886').reply(200, zaak1);
+  axiosMock.onGet('/zaken/api/v1/zaken/noStatus').reply(200, zaak1noStatus);
+  axiosMock.onGet('/zaken/api/v1/statussen/9f14d7b0-8f00-4827-9b99-d77ae5d8d155').reply(200, statusvoorbeeld);
+  axiosMock.onGet(/\/zaken\/api\/v1\/statussen\/.+/).reply(200, statusvoorbeeld2);
+  axiosMock.onGet(/\/zaken\/api\/v1\/resultaten\/.+/).reply(200, resultaatvoorbeeld);
+  axiosMock.onGet(/\/zaken\/api\/v1\/rollen.+/).reply(200, rol);
+  axiosMock.onGet(/\/zaken\/api\/v1\/zaakinformatieobjecten.+/).reply(200, zaakinformatieobjecten);
+  axiosMock.onGet(/\/documenten\/api\/v1\/enkelvoudiginformatieobjecten.+/).reply(200, enkelvoudiginformatiobject);
+});
+
+describe('Zaken', () => {
+  test('constructing object succeeds', async () => {
+    axiosMock.onGet().reply(200, []);
+    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
+    expect(() => { new Zaken(client, new Bsn('900222670')); }).not.toThrow();
+  });
+
+  test('a single zaak has documents',
+    async () => {
+      const bsn = new Bsn('900026236');
+      const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
+      const ZakenResults = new Zaken(client, bsn);
+      const results = await ZakenResults.documents('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      expect(results).toHaveLength(2);
+      expect(results).toBeFalsy();
+      // const results = await ZakenResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      // expect(results).toStrictEqual(
+      //   {
+      //     id: 'Z23.001592',
+      //     registratiedatum: '9 juni 2023',
+      //     verwachtte_einddatum: '1 september 2023',
+      //     einddatum: null,
+      //     uiterlijke_einddatum: '11 oktober 2023',
+      //     resultaat: null,
+      //     status: 'In behandeling',
+      //     uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+      //     zaak_type: 'Bezwaar',
+      //     status_list: [ 
+      //       {
+      //         name: 'Ontvangen',
+      //         current: false,
+      //         completed: true,
+      //         is_eind: false,
+      //         volgnummer: 1,
+      //       },
+      //       {
+      //         name: 'In behandeling',
+      //         current: true,
+      //         is_eind: false,
+      //         completed: false,
+      //         volgnummer: 2,
+      //       },
+      //       {
+      //         name: 'Afgerond',
+      //         current: false,
+      //         completed: false,
+      //         is_eind: true,
+      //         volgnummer: 3,
+      //       },
+      //     ],
+      //   });
+    });
+});

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -12,6 +12,8 @@ import zaak1 from './samples/zaak1.json';
 import zaak1noStatus from './samples/zaak1noStatus.json';
 import zaaktypen from './samples/zaaktypen.json';
 import zaken from './samples/zaken.json';
+import zaakinformatieobjecten from './samples/zaakinformatieobjecten.json';
+import enkelvoudiginformatiobject from './samples/enkelvoudiginformatieobject.json';
 import { OpenZaakClient } from '../OpenZaakClient';
 import { Zaken } from '../Zaken';
 
@@ -33,6 +35,8 @@ beforeAll(() => {
   axiosMock.onGet(/\/zaken\/api\/v1\/statussen\/.+/).reply(200, statusvoorbeeld2);
   axiosMock.onGet(/\/zaken\/api\/v1\/resultaten\/.+/).reply(200, resultaatvoorbeeld);
   axiosMock.onGet(/\/zaken\/api\/v1\/rollen.+/).reply(200, rol);
+  axiosMock.onGet(/\/zaken\/api\/v1\/zaakinformatieobjecten.+/).reply(200, zaakinformatieobjecten);
+  axiosMock.onGet(/\/documenten\/api\/v1\/enkelvoudiginformatieobjecten.+/).reply(200, enkelvoudiginformatiobject);
 });
 
 describe('Zaken', () => {
@@ -128,6 +132,20 @@ describe('Zaken', () => {
               volgnummer: 3,
             },
           ],
+          documenten: [
+            {
+            beschrijving: "",
+            registratieDatum: "2023-10-03T11:33:45.683874Z",
+            titel: "test docx",
+            url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+            },
+            {
+              beschrijving: "",
+              registratieDatum: "2023-10-03T11:33:45.683874Z",
+              titel: "test docx",
+              url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+            },
+          ],
         });
     });
 
@@ -169,6 +187,20 @@ describe('Zaken', () => {
       ],
       uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
       zaak_type: 'Bezwaar',
+      documenten: [
+        {
+        beschrijving: "",
+        registratieDatum: "2023-10-03T11:33:45.683874Z",
+        titel: "test docx",
+        url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+        },
+        {
+          beschrijving: "",
+          registratieDatum: "2023-10-03T11:33:45.683874Z",
+          titel: "test docx",
+          url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+        },
+      ],
     });
   });
 
@@ -188,6 +220,20 @@ describe('Zaken', () => {
       status_list: null,
       uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
       zaak_type: 'Bezwaar',
+      documenten: [
+        {
+        beschrijving: "",
+        registratieDatum: "2023-10-03T11:33:45.683874Z",
+        titel: "test docx",
+        url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+        },
+        {
+          beschrijving: "",
+          registratieDatum: "2023-10-03T11:33:45.683874Z",
+          titel: "test docx",
+          url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+        },
+      ],
     });
   });
 
@@ -308,6 +354,20 @@ describe('Filtering domains', () => {
               is_eind: true,
               completed: false,
               volgnummer: 3,
+            },
+          ],
+          documenten: [
+            {
+            beschrijving: "",
+            registratieDatum: "2023-10-03T11:33:45.683874Z",
+            titel: "test docx",
+            url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+            },
+            {
+              beschrijving: "",
+              registratieDatum: "2023-10-03T11:33:45.683874Z",
+              titel: "test docx",
+              url: "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
             },
           ],
         });

--- a/src/app/zaken/tests/samples/enkelvoudiginformatieobject.json
+++ b/src/app/zaken/tests/samples/enkelvoudiginformatieobject.json
@@ -1,0 +1,33 @@
+{
+    "url": "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+    "identificatie": "DOCUMENT-2023-0000000007",
+    "bronorganisatie": "001479179",
+    "creatiedatum": "2023-07-05",
+    "titel": "test docx",
+    "vertrouwelijkheidaanduiding": "zaakvertrouwelijk",
+    "auteur": "Michel",
+    "status": "definitief",
+    "formaat": "text/plain",
+    "taal": "nld",
+    "versie": 1,
+    "beginRegistratie": "2023-10-03T11:33:45.683874Z",
+    "bestandsnaam": "",
+    "inhoud": "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0/download?versie=1",
+    "bestandsomvang": 16893,
+    "link": "",
+    "beschrijving": "",
+    "ontvangstdatum": null,
+    "verzenddatum": null,
+    "indicatieGebruiksrecht": null,
+    "ondertekening": {
+        "soort": "",
+        "datum": null
+    },
+    "integriteit": {
+        "algoritme": "",
+        "waarde": "",
+        "datum": null
+    },
+    "informatieobjecttype": "/catalogi/api/v1/informatieobjecttypen/ad05e7f5-9484-40c1-8f4e-150f09e961ae",
+    "locked": false
+}

--- a/src/app/zaken/tests/samples/zaakinformatieobjecten.json
+++ b/src/app/zaken/tests/samples/zaakinformatieobjecten.json
@@ -1,0 +1,22 @@
+[
+    {
+        "url": "/zaken/api/v1/zaakinformatieobjecten/757ea2f9-ddd6-466b-8b0d-83a2309ce9ac",
+        "uuid": "757ea2f9-ddd6-466b-8b0d-83a2309ce9ac",
+        "informatieobject": "/documenten/api/v1/enkelvoudiginformatieobjecten/634d7c96-9fe2-4dee-b389-fcd2c5beb2d0",
+        "zaak": "/zaken/api/v1/zaken/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886",
+        "aardRelatieWeergave": "Hoort bij, omgekeerd: kent",
+        "titel": "test docx",
+        "beschrijving": "",
+        "registratiedatum": "2023-10-03T11:33:45.978291Z"
+    },
+    {
+        "url": "/zaken/api/v1/zaakinformatieobjecten/6af156fe-206f-451c-b972-6b5f700091d8",
+        "uuid": "6af156fe-206f-451c-b972-6b5f700091d8",
+        "informatieobject": "/documenten/api/v1/enkelvoudiginformatieobjecten/94531518-25a3-4b06-8eb1-1a076d2ba93f",
+        "zaak": "/zaken/api/v1/zaken/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886",
+        "aardRelatieWeergave": "Hoort bij, omgekeerd: kent",
+        "titel": "",
+        "beschrijving": "",
+        "registratiedatum": "2023-10-03T11:33:32.680667Z"
+    }
+]


### PR DESCRIPTION
Uses the document API to get documents for zaken (only for single zaak), and shows these on the zaak-page.

Fixes #70 