### PR TITLE
feat: flag live tasks

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -13,6 +13,19 @@ export interface Configuration {
   branchName: string;
   deployFromEnvironment: Environment;
   deployToEnvironment: Environment;
+
+  /**
+   * Feature flag: if this is not true, the lambda will
+   * return 404.
+   */
+  readonly isLive?: boolean;
+
+  /**
+   * Feature flag: The taken functionality is experimental
+   * If this flag is not true, the taken-functionality will
+   * always exit immediately.
+   */
+  readonly useTaken?: boolean;
 }
 
 export const configurations: {[key: string]: Configuration} = {
@@ -20,6 +33,15 @@ export const configurations: {[key: string]: Configuration} = {
     branchName: 'acceptance',
     deployFromEnvironment: Statics.deploymentEnvironment,
     deployToEnvironment: Statics.acceptanceEnvironment,
+    useTaken: true,
+    isLive: true,
+  },
+  production: {
+    branchName: 'main',
+    deployFromEnvironment: Statics.deploymentEnvironment,
+    deployToEnvironment: Statics.productionEnvironment,
+    useTaken: false,
+    isLive: false,
   },
 };
 

--- a/src/ZakenApiStage.ts
+++ b/src/ZakenApiStage.ts
@@ -14,6 +14,6 @@ export class ZakenApiStage extends Stage {
     super(scope, id, props);
     Aspects.of(this).add(new PermissionsBoundaryAspect());
 
-    new ZakenApiStack(this, 'zaken-api');
+    new ZakenApiStack(this, 'zaken-api', { configuration: props.configuration });
   }
 }

--- a/src/app/zaken/tests/samples/tmp2.html
+++ b/src/app/zaken/tests/samples/tmp2.html
@@ -1,0 +1,250 @@
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <link rel="shortcut icon" href="https://mijn.accp.nijmegen.nl/static/favicon.ico" type="image/x-icon">
+  <!-- Preload fonts and external styles -->
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,700&amp;display=swap">
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
+  
+  <link rel="preload" as="font" href="https://mijn.accp.nijmegen.nl/static/fonts/oranda_bold_bt.04c85cb2.woff2" type="font/woff2" crossorigin="anonymous">
+  <link rel="preload" as="font" href="https://mijn.accp.nijmegen.nl/static/fonts/oranda_bold_bt.8e266873.woff" type="font/woff" crossorigin="anonymous">
+  <link rel="preload" as="font" href="https://mijn.accp.nijmegen.nl/static/fonts/oranda_bt.bde3d05f.woff2" type="font/woff2" crossorigin="anonymous">
+  <link rel="preload" as="font" href="https://mijn.accp.nijmegen.nl/static/fonts/oranda_bt.05235f9a.woff" type="font/woff" crossorigin="anonymous">
+
+  <!-- Start: Core styling -->
+  <!-- Bootstrap core CSS -->
+  <link rel="stylesheet" href="https://componenten.nijmegen.nl/v6.1.0/css/bootstrap.min.css" integrity="sha512-bnCn1haQjQGPoq90nqpOWUiu9i60sex8WQI639yU2yElzx0pfG0hpaJrKuJTJD3bZ3lEUw+HRGEHrWm6TGsKSg==" crossorigin="anonymous">
+  <!-- Material Design Bootstrap combined with custom Nijmegen styles -->
+  <link rel="stylesheet" href="https://componenten.nijmegen.nl/v6.1.0/nijmegen.css" integrity="sha512-blgrU3wXs0CIV9iars0ZyneHar1CFTEojkN3O9sGQrkvwT4PZX5wXD6dv7Gde+mUGPhgrr9ej92UCuzDkmk7cQ==" crossorigin="anonymous">
+  <!-- End: Core styling -->
+  <link rel="stylesheet" href="https://mijn.accp.nijmegen.nl/static/styles/screen.css">
+  <link rel="stylesheet" href="https://mijn.accp.nijmegen.nl/static/styles/zaak.css">
+  <title>Mijn Nijmegen - Zaak </title>
+  <style type="text/css">/* Chart.js */
+@-webkit-keyframes chartjs-render-animation{from{opacity:0.99}to{opacity:1}}@keyframes chartjs-render-animation{from{opacity:0.99}to{opacity:1}}.chartjs-render-monitor{-webkit-animation:chartjs-render-animation 0.001s;animation:chartjs-render-animation 0.001s;}</style></head>
+<body aria-busy="true">
+<nav class="navbar fixed-top navbar-expand-lg scrolling-navbar navbar-primary">
+  <ul class="navbar-skiplinks">
+      <li>
+          <a href="#section-1 ">Direct naar inhoud</a>
+      </li>
+  </ul>
+  <div class="container">
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Menu</span>
+          <span class="navbar-toggler-icon" aria-hidden="true"></span>
+      </button>
+      <a class="navbar-brand" href="/">
+          <span class="sr-only">Hoofdpagina</span>
+          <div class="navbar-brand-container">
+              <img src="https://componenten.nijmegen.nl/v6.0.0/img/beeldmerklabelwit.svg" class="logo-labeled" alt="Logo Nijmegen">
+              <img src="https://componenten.nijmegen.nl/v6.0.0/img/beeldmerkwit.svg" class="logo" aria-hidden="true" alt="">
+          </div>
+      </a>
+      <div class="collapse navbar-collapse" id="navbar-collapse">
+          <ul class="navbar-nav mr-auto nijmegen-smooth-scroll">
+              <li class="nav-item">
+                  <a href="/" class="nav-link waves-effect waves-light">Overzicht</a>
+              </li>
+              <li class="nav-item">
+                  <a href="/persoonsgegevens" class="nav-link waves-effect waves-light">Persoonsgegevens</a>
+              </li>
+              <li class="nav-item">
+                  <a href="/uitkeringen" class="nav-link waves-effect waves-light">Uitkeringen</a>
+              </li>
+              <li class="nav-item">
+                  <a href="/zaken" class="nav-link waves-effect waves-light">Zaken</a>
+              </li>
+          </ul>
+          <ul class="navbar-nav ml-auto">
+              <li class="nav-item">
+                  <a class="nav-link nav-no-link waves-effect waves-light" href="/logout">N. Boeddhoe
+                      <svg title="uitloggen" class="mdi mdi-logout" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M16,17V14H9V10H16V7L21,12L16,17M14,2A2,2 0 0,1 16,4V6H14V4H5V20H14V18H16V20A2,2 0 0,1 14,22H5A2,2 0 0,1 3,20V4A2,2 0 0,1 5,2H14Z"></path></svg>
+                  </a>
+              </li>
+          </ul>
+      </div>
+  </div>
+</nav>
+
+<main id="denhaag-theme">
+  <!-- START: template component(s) -->
+  <div class="container denhaag-theme" id="section-1">
+      <div class="row">
+          <div class="col-12">
+              <h1>Evenementenvergunning</h1>
+              <p class="lead">Uw aanvraag met kenmerk <strong>Z23.001759</strong> is door ons ontvangen op <strong>5 oktober 2023</strong>. De status is <strong>In behandeling</strong>. We verwachten uw aanvraag af te ronden op 30 november 2023.</p>
+              <div class="denhaag-action">
+                  <div class="denhaag-action__content">
+                      We missen nog het veiligheidsplan voor uw evenement, zou u deze willen uploaden via het formulier.
+                  </div>
+                  <div class="denhaag-action__details">
+                      <div class="denhaag-action__date">
+                      <span>
+                      </span>
+                      </div>
+                      <div class="denhaag-action__actions">
+                      Ingediend ✅
+                      </div>
+                  </div>
+              </div>
+              <h2>Het verloop van uw aanvraag</h2>
+              <ol class="denhaag-process-steps">
+                  <li class="denhaag-process-steps__step denhaag-process-steps__step--checked">  
+                      <div class="denhaag-process-steps__step-header">
+                      <div class="denhaag-step-marker denhaag-step-marker--checked">
+                          <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" class="denhaag-icon" focusable="false" aria-hidden="true" shape-rendering="auto">
+                          <path d="M20.664 5.253a1 1 0 01.083 1.411l-10.666 12a1 1 0 01-1.495 0l-5.333-6a1 1 0 011.494-1.328l4.586 5.159 9.92-11.16a1 1 0 011.411-.082z" stroke="currentColor" stroke-width="1.75"></path>
+                          </svg>
+                      </div>
+                      <p class="denhaag-process-steps__step-heading denhaag-process-steps__step-heading--checked">
+                          Ontvangen
+                      </p>
+                      </div>
+                      <div class="denhaag-process-steps__step-body">
+                      
+                          <div class="denhaag-step-marker__connector denhaag-step-marker__connector--checked denhaag-step-marker__connector--main-to-main">
+                      </div>
+                  </div></li>
+                  <li class="denhaag-process-steps__step denhaag-process-steps__step--current">  
+                      <div class="denhaag-process-steps__step-header">
+                      <div class="denhaag-step-marker denhaag-step-marker--current">
+                          2
+                      </div>
+                      <p class="denhaag-process-steps__step-heading denhaag-process-steps__step-heading--current">
+                          In behandeling
+                      </p>
+                      </div>
+                      <div class="denhaag-process-steps__step-body">
+                      
+                          <div class="denhaag-step-marker__connector denhaag-step-marker__connector--current denhaag-step-marker__connector--main-to-main">
+                      </div>
+                  </div></li>
+                  <li class="denhaag-process-steps__step denhaag-process-steps__step--not-checked">  
+                      <div class="denhaag-process-steps__step-header">
+                      <div class="denhaag-step-marker denhaag-step-marker--not-checked">
+                          3
+                      </div>
+                      <p class="denhaag-process-steps__step-heading denhaag-process-steps__step-heading--not-checked">
+                          Zaak afgerond
+                      </p>
+                      </div>
+                      <div class="denhaag-process-steps__step-body">
+                      <div>Verwacht op 30 november 2023</div>
+
+                      </div>
+                  </li>
+              </ol>
+
+              <h2>Documenten</h2>
+              <ul>
+                      <li><a href="https://openzaak.woweb.app/documenten/api/v1/enkelvoudiginformatieobjecten/ce50607a-45bf-449f-b3b8-d8a1dd8e2e81">vergunningaanvraag-benefietconcert.pdf</a></li>
+                      <li><a href="https://openzaak.woweb.app/documenten/api/v1/enkelvoudiginformatieobjecten/a551e695-7d6a-4fda-95a3-8b3cf7799045">Pdf van de aanvraag van zaak</a></li>
+              </ul>
+          </div>
+      </div>
+  </div>
+
+  <!-- END: template component(s) -->
+</main>
+<footer class="page-footer">
+      <div class="footer-content">
+          <div class="container">
+              <div class="row">
+                  <div class="hidden-md-down col-lg-6">
+                      <h2 class="title">Mijn Nijmegen</h2>
+                      <div class="link-list-wrapper">
+                          <ul class="link-list">
+                              <li><a href="/persoonsgegevens">Persoonsgegevens</a></li>
+                              <li><a href="/uitkeringen">Uitkeringen</a></li>
+                              <li><a href="/zaken">Zaken</a></li>
+                          </ul>
+                      </div>
+                  </div>
+                  <div class="col-md-12 col-lg-6">
+                      <div class="row">
+                          <div class="hidden-md-down col-lg-5">
+                              <h2 class="title">Over deze site</h2>
+                              <ul class="link-list">
+                                  <li><a href="https://www.nijmegen.nl/toegankelijkheid/">Toegankelijkheid</a></li>
+                                  <li><a href="https://www.nijmegen.nl/diensten/privacy/">Privacyverklaring</a></li>
+                                  <li><a href="https://www.nijmegen.nl/cookies/">Cookies</a></li>
+                                  <li><a href="https://www.nijmegen.nl/proclaimer/">Proclaimer</a></li>
+                                  <li><a href="https://www.nijmegen.nl/sitemap/">Sitemap</a></li>
+                              </ul>
+                          </div>
+
+                          <div class="col-xs-12 col-md-6 col-lg-7">
+                              <h2 class="title">Contactgegevens</h2>
+                              <ul class="link-list contact-list">
+                                  <li>
+                                      <svg aria-hidden="true" class="mdi mdi-map-marker" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M12,11.5A2.5,2.5 0 0,1 9.5,9A2.5,2.5 0 0,1 12,6.5A2.5,2.5 0 0,1 14.5,9A2.5,2.5 0 0,1 12,11.5M12,2A7,7 0 0,0 5,9C5,14.25 12,22 12,22C12,22 19,14.25 19,9A7,7 0 0,0 12,2Z"></path></svg>
+                                      <span class="sr-only">Bekijk onze locatie:</span>
+                                      <a href="https://www.google.nl/maps/place/Municipality+of+Nijmegen+(Stadswinkel)/@51.8453377,5.8650266,17z/data=!3m1!4b1!4m5!3m4!1s0x47c708453b48b901:0x73b58e3e154d4f0b!8m2!3d51.8453377!4d5.8672206">
+                                          Stadswinkel, Mariënburg 30
+                                      </a>
+                                  </li>
+                                  <li>
+                                      <svg class="mdi mdi-phone" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M6.62,10.79C8.06,13.62 10.38,15.94 13.21,17.38L15.41,15.18C15.69,14.9 16.08,14.82 16.43,14.93C17.55,15.3 18.75,15.5 20,15.5A1,1 0 0,1 21,16.5V20A1,1 0 0,1 20,21A17,17 0 0,1 3,4A1,1 0 0,1 4,3H7.5A1,1 0 0,1 8.5,4C8.5,5.25 8.7,6.45 9.07,7.57C9.18,7.92 9.1,8.31 8.82,8.59L6.62,10.79Z"></path></svg>
+                                      <span class="sr-only">Bel ons:</span>
+                                      <a href="tel:14024">
+                                          14 024
+                                      </a>
+                                  </li>
+                                  <li>
+                                      <svg class="mdi mdi-email" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M20,8L12,13L4,8V6L12,11L20,6M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z"></path></svg>
+                                      <span class="sr-only">Mail ons:</span>
+                                      <a href="mailto:gemeente@nijmegen.nl">
+                                          gemeente@nijmegen.nl
+                                      </a>
+                                  </li>
+                                  <li>
+                                      <svg class="mdi mdi-facebook" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2.04C6.5 2.04 2 6.53 2 12.06C2 17.06 5.66 21.21 10.44 21.96V14.96H7.9V12.06H10.44V9.85C10.44 7.34 11.93 5.96 14.22 5.96C15.31 5.96 16.45 6.15 16.45 6.15V8.62H15.19C13.95 8.62 13.56 9.39 13.56 10.18V12.06H16.34L15.89 14.96H13.56V21.96A10 10 0 0 0 22 12.06C22 6.53 17.5 2.04 12 2.04Z"></path></svg>
+                                      <span class="sr-only">Vind ons op facebook:</span>
+                                      <a href="https://www.facebook.com/gemeentenijmegen">
+                                          Gemeente Nijmegen
+                                      </a>
+                                  </li>
+                                  <li>
+                                      <svg class="mdi mdi-twitter" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M22.46,6C21.69,6.35 20.86,6.58 20,6.69C20.88,6.16 21.56,5.32 21.88,4.31C21.05,4.81 20.13,5.16 19.16,5.36C18.37,4.5 17.26,4 16,4C13.65,4 11.73,5.92 11.73,8.29C11.73,8.63 11.77,8.96 11.84,9.27C8.28,9.09 5.11,7.38 3,4.79C2.63,5.42 2.42,6.16 2.42,6.94C2.42,8.43 3.17,9.75 4.33,10.5C3.62,10.5 2.96,10.3 2.38,10C2.38,10 2.38,10 2.38,10.03C2.38,12.11 3.86,13.85 5.82,14.24C5.46,14.34 5.08,14.39 4.69,14.39C4.42,14.39 4.15,14.36 3.89,14.31C4.43,16 6,17.26 7.89,17.29C6.43,18.45 4.58,19.13 2.56,19.13C2.22,19.13 1.88,19.11 1.54,19.07C3.44,20.29 5.7,21 8.12,21C16,21 20.33,14.46 20.33,8.79C20.33,8.6 20.33,8.42 20.32,8.23C21.16,7.63 21.88,6.87 22.46,6Z"></path></svg>
+                                      <span class="sr-only">Volg ons op Twitter:</span>
+                                      <a href="https://twitter.com/gem_nijmegen">
+                                          @nijmegen
+                                      </a>
+                                  </li>
+                              </ul>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+      <div class="footer-copyright text-center">
+          <div class="container-fluid">
+              <img src="https://componenten.nijmegen.nl/v6.1.0/img/beeldmerkwit.svg" height="32" width="25" class="logo-labeled" alt="Logo Gemeente Nijmegen">
+              Gemeente Nijmegen
+          </div>
+      </div>
+  </footer>
+<!-- JQuery -->
+<script src="https://componenten.nijmegen.nl/v6.1.0/js/jquery.min.js" integrity="sha512-pV9V1WiZq0QO8MrheyjVzI9bl2bR6bwaisa4k3aSS0dsGrDDJUl+tdRK9B9Ov47qI22Ho2kCJEuKPspUmUuHEQ==" crossorigin="anonymous"></script>
+
+<!-- Bootstrap tooltips -->
+<script src="https://componenten.nijmegen.nl/v6.1.0/js/popper.min.js" integrity="sha512-lWJ53t3FjWFXcLO7CWRG8vJABfUOuSuMZspt8g2nDyx/ft/B+Zb5jBSjED4Qyze4tp2DqVECV9fHo3j1bzpChw==" crossorigin="anonymous"></script>
+
+<!-- Bootstrap core JavaScript -->
+<script src="https://componenten.nijmegen.nl/v6.1.0/js/bootstrap.min.js" integrity="sha512-uIuDDliVdzuBgB2Ocut6cVdPSGZ6/my59sSOQlwnGi1qtuyyDVzj+8fr/HUr84mBlCs3zGBttci2JSALm8WMNg==" crossorigin="anonymous"></script>
+
+<!-- MDB core JavaScript -->
+<script src="https://componenten.nijmegen.nl/v6.1.0/js/mdb.min.js" integrity="sha512-HTOV7Smd7fT2VtLuwZP+BQ4riX9YHbVMGJ22X1wMcHSNx4JIkE/1KS6ux4S78pdf8orN82idrE36YHccsaHnTA==" crossorigin="anonymous"></script>
+
+<!-- Nijmegen specific script -->
+<script src="https://componenten.nijmegen.nl/v6.1.0/nijmegen.js" integrity="sha512-whPa7XgHBxAZ7Tz1v1cIytLsPEuxFbOnq+mCDHCyBhSk+2sOIouiU66p1moY2loVtQ8/oebuxmjDVflhuGKkmA==" crossorigin="anonymous"></script>
+
+<!-- End: Core scripts -->
+<!-- Start: Additional component(s) script -->
+<!-- ... -->
+<!-- End: Additional component(s) script -->
+
+<div class="hiddendiv common"></div></body></html>

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -29,6 +29,9 @@ function parseEvent(event: APIGatewayProxyEventV2): any {
 }
 
 export async function handler(event: any, _context: any):Promise<ApiGatewayV2Response> {
+  if (!isAllowed()) {
+    return Response.error(404);
+  }
   try {
     const params = parseEvent(event);
     const secrets = await initPromise;
@@ -53,4 +56,12 @@ function sharedOpenZaakClient(secret: string): OpenZaakClient {
     });
   }
   return openZaakClient;
+}
+
+/** Check if this function is live */
+function isAllowed() {
+  if (process.env.IS_LIVE == 'true') {
+    return true;
+  }
+  return false;
 }

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -45,7 +45,6 @@ export async function zakenRequestHandler(
 }
 
 async function listZakenRequest(session: Session, client: OpenZaakClient) {
-
   console.timeLog('request', 'Api Client init');
 
   let data = {
@@ -91,8 +90,16 @@ async function singleZaakRequest(session: Session, client: OpenZaakClient, zaak:
   return Response.html(html, 200, session.getCookie());
 }
 
-
-function taken(secret: string): Taken {
+/**
+ * Return taken object, or undefined if the taken functionality
+ * is not yet live. (controlled by the USE_TAKEN env. param).
+ *
+ * @param secret secret for the taken endpoint
+ */
+function taken(secret: string): Taken|undefined {
+  if (!TakenIsAllowed()) {
+    return;
+  }
   if (!process.env.VIP_TOKEN_BASE_URL) {
     throw Error('No VIP_TOKEN_BASE_URL provided');
   }
@@ -110,5 +117,14 @@ function taken(secret: string): Taken {
   });
 
   return new Taken(openZaakClient);
+}
 
+/**
+ * Check if the taken functionality should be live
+ */
+function TakenIsAllowed() {
+  if (process.env.USE_TAKEN === 'true') {
+    return true;
+  }
+  return false;
 }

--- a/src/statics.ts
+++ b/src/statics.ts
@@ -35,5 +35,9 @@ export abstract class Statics {
     region: 'eu-central-1',
   };
 
+  static readonly productionEnvironment = {
+    account: '740606269759',
+    region: 'eu-central-1',
+  };
 
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,11 +2,18 @@ import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { PipelineStack } from '../src/PipelineStack';
 import { ZakenApiStack } from '../src/ZakenApiStack';
+import { Configuration } from '../src/Configuration';
 
 const dummyEnv = {
   account: '123456789012',
   region: 'eu-west-1',
 };
+
+const config: Configuration = {
+  branchName: 'test',
+  deployFromEnvironment: dummyEnv,
+  deployToEnvironment: dummyEnv,
+}
 
 test('Snapshot', () => {
   const app = new App();
@@ -24,7 +31,8 @@ test('Snapshot', () => {
 
 test('StackHasLambdas', () => {
   const app = new App();
-  const stack = new ZakenApiStack(app, 'api');
+  
+  const stack = new ZakenApiStack(app, 'api', {configuration: config});
   const template = Template.fromStack(stack);
   template.resourceCountIs('AWS::Lambda::Function', 2); //Setting log retention creates a lambda
 });


### PR DESCRIPTION
To allow us to push this to production, without going live, this
commit adds a flag to the configuration object for setting the live
status of the app. If the app is not live, the /zaken/ routes will
return http 404.

We also add a flag for the 'taken'-component. This is experimental,
and should not be live yet, even when the app itself can go live.


fixes #230 