### PR TITLE
feat: Modify getConfiguration to use branchname

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -10,7 +10,8 @@ export interface Configurable {
 }
 
 export interface Configuration {
-  branchName: string;
+  name: string; // Name (for the pipeline)
+  branchName: string; // Branch (for the source)
   deployFromEnvironment: Environment;
   deployToEnvironment: Environment;
 
@@ -31,6 +32,7 @@ export interface Configuration {
 export const configurations: {[key: string]: Configuration} = {
   acceptance: {
     branchName: 'acceptance',
+    name: 'acceptance',
     deployFromEnvironment: Statics.deploymentEnvironment,
     deployToEnvironment: Statics.acceptanceEnvironment,
     useTaken: true,
@@ -38,6 +40,7 @@ export const configurations: {[key: string]: Configuration} = {
   },
   production: {
     branchName: 'main',
+    name: 'production',
     deployFromEnvironment: Statics.deploymentEnvironment,
     deployToEnvironment: Statics.productionEnvironment,
     useTaken: false,
@@ -45,10 +48,17 @@ export const configurations: {[key: string]: Configuration} = {
   },
 };
 
-export function getConfiguration(branchName: string) {
-  const config = configurations[branchName];
-  if (!config) {
-    throw new Error(`Configuration for branch ${branchName} not found`);
+/**
+ * Get a configuration object based on the `branchName` key
+ * @param branchName branch Name for which to get config
+ */
+export function getConfiguration(branchName: string): Configuration {
+  const configName = Object.keys(configurations).find((configurationName) => {
+    const config = configurations[configurationName];
+    return config.branchName == branchName;
+  });
+  if (configName) {
+    return configurations[configName];
   }
-  return config;
+  throw Error(`No configuration found for branch name ${branchName}`);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ const app = new App();
 const deployBranch = process.env.BRANCH_NAME ?? 'acceptance';
 const configuration = getConfiguration(deployBranch);
 
-new PipelineStack(app, `mijn-zaken-pipeline-${configuration.branchName}`,
+new PipelineStack(app, `mijn-zaken-pipeline-${configuration.name}`,
   {
     env: configuration.deployFromEnvironment,
     configuration,

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -1,0 +1,11 @@
+import { getConfiguration } from '../src/Configuration';
+
+describe('Test configuration', () => {
+  test('Branch name matches key', async() => {
+    expect(getConfiguration('acceptance').name).toBe('acceptance');
+  });
+
+  test('Branch name is different from environment key', async() => {
+    expect(getConfiguration('main').name).toBe('production');
+  });
+});


### PR DESCRIPTION
And add a setting for the 'name' of the config, this wil result in a pipeline that is called 'project-{nameFromConfig}' instead of 'project-{branchName}'. (so prod is called production and not 'main').

Required for #232 