### PR TITLE
feat: kvk zaken

### DIFF
--- a/src/app/zaken/OpenZaakClient.ts
+++ b/src/app/zaken/OpenZaakClient.ts
@@ -3,16 +3,16 @@ import jwt from 'jsonwebtoken';
 
 export class OpenZaakClient {
   private axios: Axios;
-  public baseUrl: URL;
+  public baseUrl: string;
 
   constructor(config: {
-    baseUrl: URL;
+    baseUrl: URL | string;
     axiosInstance?: AxiosInstance;
     clientId?: string;
     userId?: string;
     secret?: string;
   }) {
-    this.baseUrl = config.baseUrl;
+    this.baseUrl = config.baseUrl.toString();
     this.axios = this.initAxios(config);
     if (process.env.DEBUG) {
       this.axios.interceptors.request.use(function (configuration) {
@@ -29,7 +29,7 @@ export class OpenZaakClient {
     clientId?: string | undefined;
     userId?: string | undefined;
     secret?: string | undefined;
-    baseUrl: URL;}) {
+    }) {
     if (config.axiosInstance) {
       return config.axiosInstance;
     } else {
@@ -38,7 +38,7 @@ export class OpenZaakClient {
       }
       return axios.create(
         {
-          baseURL: config.baseUrl.toString(),
+          baseURL: this.baseUrl,
           headers: {
             'Authorization': 'Bearer ' + this.jwtToken(config.clientId, config.userId, config.secret),
             'Accept-Crs': 'EPSG:4326',

--- a/src/app/zaken/OpenZaakClient.ts
+++ b/src/app/zaken/OpenZaakClient.ts
@@ -29,7 +29,7 @@ export class OpenZaakClient {
     clientId?: string | undefined;
     userId?: string | undefined;
     secret?: string | undefined;
-    }) {
+  }) {
     if (config.axiosInstance) {
       return config.axiosInstance;
     } else {

--- a/src/app/zaken/OpenZaakClient.ts
+++ b/src/app/zaken/OpenZaakClient.ts
@@ -61,7 +61,6 @@ export class OpenZaakClient {
   }
 
   async request(endpoint: string, params?: URLSearchParams): Promise<any> {
-    console.count('aantal requests');
     const paramString = params ? `?${params}` : '';
     const url =`${endpoint}${paramString}`;
     try {
@@ -76,7 +75,6 @@ export class OpenZaakClient {
       if (error.response) {
         // The request was made and the server responded with a status code
         // that falls out of the range of 2xx
-        console.log(error.response.data);
         console.log(error.response.status);
         console.log(error.response.headers);
       } else if (error.request) {

--- a/src/app/zaken/User.ts
+++ b/src/app/zaken/User.ts
@@ -1,0 +1,39 @@
+import { Bsn } from "@gemeentenijmegen/utils";
+
+/**
+ * Several types of user exist:
+ * - 'Natuurlijk persoon' (a human), having a BSN and a name (provided by the BRP)
+ * - 'Organisation', having a KVK identification number, and a company name (provided by eherkenning)
+ */
+export interface User {
+  identifier: string;
+  type: 'person' | 'organisation';
+}
+
+/**
+ * Implementation of a 'natuurlijk persoon', a human, having a BSN.
+ */
+export class Person implements User {
+  bsn: Bsn;
+  identifier: string;
+  userName?: string;
+  type: 'person' | 'organisation' = 'person';
+  constructor(bsn: Bsn) {
+    this.bsn = bsn;
+    this.identifier = bsn.bsn;
+  }
+}
+
+/**
+ * Implementation of a user of type 'organisation', having a KVK number.
+ */
+export class Organisation implements User {
+  kvk: string;
+  identifier: string;
+  type: 'person' | 'organisation' = 'organisation';
+
+  constructor(kvk: string) {
+    this.kvk = kvk;
+    this.identifier = kvk;
+  }
+}

--- a/src/app/zaken/User.ts
+++ b/src/app/zaken/User.ts
@@ -1,4 +1,4 @@
-import { Bsn } from "@gemeentenijmegen/utils";
+import { Bsn } from '@gemeentenijmegen/utils';
 
 /**
  * Several types of user exist:

--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -65,7 +65,7 @@ export class Zaken {
     await this.metaData();
 
     let zaken;
-    if(this.user.type == 'person') {
+    if (this.user.type == 'person') {
       const params = new URLSearchParams({
         rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn: this.user.identifier,
         ordering: '-startdatum',
@@ -74,14 +74,14 @@ export class Zaken {
 
       // Get all zaken
       zaken = await this.client.request('/zaken/api/v1/zaken', params);
-      
-    } else if(this.user.type == 'organisation') {
+
+    } else if (this.user.type == 'organisation') {
       const params = new URLSearchParams({
         betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie: this.user.identifier,
       });
       const roles = await this.client.request('/zaken/api/v1/rollen', params);
       const zaakUrls = roles?.results?.map((role: any) => role.zaak);
-      if(zaakUrls) {
+      if (zaakUrls) {
         const zakenResults = await Promise.all(zaakUrls.map((zaakUrl: string) => this.client.request(zaakUrl)));
         zaken = { results: zakenResults };
       }
@@ -101,7 +101,7 @@ export class Zaken {
     console.timeLog('zaken status', 'awaiting metadata');
     await this.metaData();
     let roleUrl;
-    if(this.user.type == 'person') {
+    if (this.user.type == 'person') {
       roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=${this.user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
     } else {
       roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie=${this.user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
@@ -212,7 +212,7 @@ export class Zaken {
         status: status_type,
         resultaat: resultaat_type,
       };
-      console.debug('summary', summary)
+      console.debug('summary', summary);
       if (resultaat) {
         zaak_summaries.gesloten.push(summary);
       } else {

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -16,6 +16,7 @@ import zaaktypen from './samples/zaaktypen.json';
 import zaken from './samples/zaken.json';
 import { OpenZaakClient } from '../OpenZaakClient';
 import { Zaken } from '../Zaken';
+import { Person } from '../User';
 
 let baseUrl = new URL('http://localhost');
 if (process.env.VIP_BASE_URL) {
@@ -40,16 +41,16 @@ beforeAll(() => {
 });
 
 describe('Zaken', () => {
+  const person = new Person(new Bsn('900222670'));
+  const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('constructing object succeeds', async () => {
     axiosMock.onGet().reply(200, []);
     const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    expect(() => { new Zaken(client, new Bsn('900222670')); }).not.toThrow();
+    expect(() => { new Zaken(client,new Person(new Bsn('900222670'))); }).not.toThrow();
   });
 
   test('zaken are processed correctly', async () => {
-    const bsn = new Bsn('900026236');
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    const statusResults = new Zaken(client, bsn);
+    const statusResults = new Zaken(client, person);
     const results = await statusResults.list();
     expect(results).toStrictEqual({
       open: [
@@ -94,10 +95,10 @@ describe('Zaken', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const bsn = new Bsn('900026236');
+      const person = new Person(new Bsn('900222670'));
       const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-      const ZakenResults = new Zaken(client, bsn);
-      const results = await ZakenResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      const statusResults = new Zaken(client, person);
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
       expect(results).toStrictEqual(
         {
           id: 'Z23.001592',
@@ -140,10 +141,10 @@ describe('Zaken', () => {
     });
 
   test('a single zaak has several statusses, which are available in the zaak', async () => {
-    const bsn = new Bsn('900026236');
+    const person = new Person(new Bsn('900222670'));
     const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    const ZakenResults = new Zaken(client, bsn, { show_documents: true });
-    const results = await ZakenResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+    const statusResults = new Zaken(client, person, { show_documents: true });
+    const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
     expect(results).toStrictEqual({
       id: 'Z23.001592',
       registratiedatum: '9 juni 2023',
@@ -198,10 +199,8 @@ describe('Zaken', () => {
   });
 
   test('a single zaak can have a null status', async () => {
-    const bsn = new Bsn('900026236');
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    const ZakenResults = new Zaken(client, bsn);
-    const results = await ZakenResults.get('noStatus');
+    const statusResults = new Zaken(client, person);
+    const results = await statusResults.get('noStatus');
     expect(results).toStrictEqual({
       id: 'Z23.001592',
       registratiedatum: '9 juni 2023',
@@ -240,10 +239,10 @@ describe('Zaken', () => {
 });
 
 describe('Filtering domains', () => {
+  const person = new Person(new Bsn('900222670'));
+  const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('zaken are filtered (APV)', async () => {
-    const bsn = new Bsn('900026236');
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    const statusResults = new Zaken(client, bsn);
+    const statusResults = new Zaken(client, person);
     statusResults.allowDomains(['APV']);
     const results = await statusResults.list();
     expect(results).toStrictEqual({
@@ -263,9 +262,7 @@ describe('Filtering domains', () => {
   });
 
   test('zaken are filtered (JZ)', async () => {
-    const bsn = new Bsn('900026236');
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    const statusResults = new Zaken(client, bsn);
+    const statusResults = new Zaken(client, person);
     statusResults.allowDomains(['JZ']);
     const results = await statusResults.list();
     expect(results).toStrictEqual({
@@ -300,9 +297,9 @@ describe('Filtering domains', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const bsn = new Bsn('900026236');
+      const person = new Person(new Bsn('900222670'));
       const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-      const statusResults = new Zaken(client, bsn);
+      const statusResults = new Zaken(client, person);
       statusResults.allowDomains(['JZ']);
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
       expect(results).toStrictEqual(
@@ -347,9 +344,9 @@ describe('Filtering domains', () => {
     });
   test('a single zaak is filtered correctly (APV)',
     async () => {
-      const bsn = new Bsn('900026236');
+      const person = new Person(new Bsn('900222670'));
       const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-      const statusResults = new Zaken(client, bsn);
+      const statusResults = new Zaken(client, person);
       statusResults.allowDomains(['APV']);
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
       expect(results).toBeFalsy();

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -15,8 +15,8 @@ import zaakinformatieobjecten from './samples/zaakinformatieobjecten.json';
 import zaaktypen from './samples/zaaktypen.json';
 import zaken from './samples/zaken.json';
 import { OpenZaakClient } from '../OpenZaakClient';
-import { Zaken } from '../Zaken';
 import { Person } from '../User';
+import { Zaken } from '../Zaken';
 
 let baseUrl = new URL('http://localhost');
 if (process.env.VIP_BASE_URL) {
@@ -45,8 +45,7 @@ describe('Zaken', () => {
   const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('constructing object succeeds', async () => {
     axiosMock.onGet().reply(200, []);
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
-    expect(() => { new Zaken(client,new Person(new Bsn('900222670'))); }).not.toThrow();
+    expect(() => { new Zaken(client, new Person(new Bsn('900222670'))); }).not.toThrow();
   });
 
   test('zaken are processed correctly', async () => {
@@ -95,8 +94,6 @@ describe('Zaken', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const person = new Person(new Bsn('900222670'));
-      const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
       const statusResults = new Zaken(client, person);
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
       expect(results).toStrictEqual(
@@ -141,8 +138,6 @@ describe('Zaken', () => {
     });
 
   test('a single zaak has several statusses, which are available in the zaak', async () => {
-    const person = new Person(new Bsn('900222670'));
-    const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
     const statusResults = new Zaken(client, person, { show_documents: true });
     const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
     expect(results).toStrictEqual({
@@ -297,8 +292,6 @@ describe('Filtering domains', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const person = new Person(new Bsn('900222670'));
-      const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
       const statusResults = new Zaken(client, person);
       statusResults.allowDomains(['JZ']);
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
@@ -344,8 +337,6 @@ describe('Filtering domains', () => {
     });
   test('a single zaak is filtered correctly (APV)',
     async () => {
-      const person = new Person(new Bsn('900222670'));
-      const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
       const statusResults = new Zaken(client, person);
       statusResults.allowDomains(['APV']);
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');

--- a/src/app/zaken/tests/ZakenKvk.test.ts
+++ b/src/app/zaken/tests/ZakenKvk.test.ts
@@ -1,0 +1,120 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import catalogi from './samples/catalogi.json';
+import enkelvoudiginformatiobject from './samples/enkelvoudiginformatieobject.json';
+import resultaattypen from './samples/resultaattypen.json';
+import resultaatvoorbeeld from './samples/resultaatvoorbeeld.json';
+import rollen from './samples/rollen.json';
+import statustypen from './samples/statustypen.json';
+import statusvoorbeeld from './samples/statusvoorbeeld.json';
+import statusvoorbeeld2 from './samples/statusvoorbeeld2.json';
+import zaak1 from './samples/zaak1.json';
+import zaak2 from './samples/zaak2.json';
+import zaak1noStatus from './samples/zaak1noStatus.json';
+import zaakinformatieobjecten from './samples/zaakinformatieobjecten.json';
+import zaaktypen from './samples/zaaktypen.json';
+import { OpenZaakClient } from '../OpenZaakClient';
+import { Zaken } from '../Zaken';
+import { Organisation } from '../User';
+
+let baseUrl = '/';
+const axiosMock = new MockAdapter(axios);
+
+beforeAll(() => {
+  axiosMock.onGet('/catalogi/api/v1/zaaktypen').reply(200, zaaktypen);
+  axiosMock.onGet('/catalogi/api/v1/statustypen').reply(200, statustypen);
+  axiosMock.onGet('/catalogi/api/v1/resultaattypen').reply(200, resultaattypen);
+  axiosMock.onGet('/catalogi/api/v1/catalogussen').reply(200, catalogi);
+  axiosMock.onGet(/\/zaken\/api\/v1\/rollen\?betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie=.+/).reply(200, rollen);
+  axiosMock.onGet('/zaken/api/v1/zaken/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886').reply(200, zaak1);
+  axiosMock.onGet('/zaken/api/v1/zaken/3720dbc1-6a94-411e-b651-0aeb67330064').reply(200, zaak2);
+  axiosMock.onGet('/zaken/api/v1/zaken/noStatus').reply(200, zaak1noStatus);
+  axiosMock.onGet('/zaken/api/v1/statussen/9f14d7b0-8f00-4827-9b99-d77ae5d8d155').reply(200, statusvoorbeeld);
+  axiosMock.onGet(/\/zaken\/api\/v1\/statussen\/.+/).reply(200, statusvoorbeeld2);
+  axiosMock.onGet(/\/zaken\/api\/v1\/resultaten\/.+/).reply(200, resultaatvoorbeeld);
+  axiosMock.onGet(/\/zaken\/api\/v1\/zaakinformatieobjecten.+/).reply(200, zaakinformatieobjecten);
+  axiosMock.onGet(/\/documenten\/api\/v1\/enkelvoudiginformatieobjecten.+/).reply(200, enkelvoudiginformatiobject);
+});
+
+describe('Zaken', () => {
+  const user = new Organisation('12345678');
+  const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
+  test('zaken are processed correctly', async () => {
+    const statusResults = new Zaken(client, user);
+    const results = await statusResults.list();
+    expect(results).toStrictEqual({
+      open: [
+        {
+          id: 'Z23.001592',
+          registratiedatum: '9 juni 2023',
+          verwachtte_einddatum: '1 september 2023',
+          einddatum: null,
+          uiterlijke_einddatum: '11 oktober 2023',
+          resultaat: null,
+          status: 'In behandeling',
+          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+          zaak_type: 'Bezwaar',
+        },
+      ],
+      gesloten: [
+        {
+          id: 'Z23.001438',
+          registratiedatum: '30 maart 2023',
+          einddatum: '28 maart 2023',
+          verwachtte_einddatum: '20 juni 2023',
+          uiterlijke_einddatum: '11 juni 2023',
+          resultaat: 'Ingetrokken na BIA',
+          status: 'In behandeling',
+          uuid: '3720dbc1-6a94-411e-b651-0aeb67330064',
+          zaak_type: 'Klacht',
+        },
+      ],
+    });
+  });
+
+  test('a single zaak is processed correctly',
+    async () => {
+      const statusResults = new Zaken(client, user);
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      expect(results).toStrictEqual(
+        {
+          id: 'Z23.001592',
+          registratiedatum: '9 juni 2023',
+          verwachtte_einddatum: '1 september 2023',
+          einddatum: null,
+          uiterlijke_einddatum: '11 oktober 2023',
+          resultaat: null,
+          status: 'In behandeling',
+          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+          zaak_type: 'Bezwaar',
+          status_list: [
+            {
+              name: 'Ontvangen',
+              current: false,
+              completed: true,
+              is_eind: false,
+              volgnummer: 1,
+            },
+            {
+              name: 'In behandeling',
+              current: true,
+              is_eind: false,
+              completed: false,
+              volgnummer: 2,
+            },
+            {
+              name: 'Afgerond',
+              current: false,
+              completed: false,
+              is_eind: true,
+              volgnummer: 3,
+            },
+          ],
+          documenten: null,
+          has_documenten: false,
+          taken: null,
+          has_taken: false,
+        });
+    });
+
+});

--- a/src/app/zaken/tests/ZakenKvk.test.ts
+++ b/src/app/zaken/tests/ZakenKvk.test.ts
@@ -9,13 +9,13 @@ import statustypen from './samples/statustypen.json';
 import statusvoorbeeld from './samples/statusvoorbeeld.json';
 import statusvoorbeeld2 from './samples/statusvoorbeeld2.json';
 import zaak1 from './samples/zaak1.json';
-import zaak2 from './samples/zaak2.json';
 import zaak1noStatus from './samples/zaak1noStatus.json';
+import zaak2 from './samples/zaak2.json';
 import zaakinformatieobjecten from './samples/zaakinformatieobjecten.json';
 import zaaktypen from './samples/zaaktypen.json';
 import { OpenZaakClient } from '../OpenZaakClient';
-import { Zaken } from '../Zaken';
 import { Organisation } from '../User';
+import { Zaken } from '../Zaken';
 
 let baseUrl = '/';
 const axiosMock = new MockAdapter(axios);

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -15,7 +15,8 @@ const getItemOutput: Partial<GetItemCommandOutput> = {
     data: {
       M: {
         loggedin: { BOOL: true },
-        bsn: { S: '900026236' },
+        identifier: { S: '900026236' },
+        user_type: { S: 'person' },
       },
     },
   },
@@ -60,6 +61,24 @@ describe('Request handler', () => {
         console.debug(error);
       }
     }
+  });
+  
+  test('returns 200 for organisation', async () => {
+    const getItemOutput: Partial<GetItemCommandOutput> = {
+      Item: {
+        data: {
+          M: {
+            loggedin: { BOOL: true },
+            identifier: { S: '69599084' },
+            user_type: { S: 'organisation' },
+          },
+        },
+      },
+    };
+    ddbMock.on(GetItemCommand).resolves(getItemOutput);
+
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zakenClient: client, takenSecret: 'test' });
+    expect(result.statusCode).toBe(200);
   });
 });
 

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -62,9 +62,9 @@ describe('Request handler', () => {
       }
     }
   });
-  
+
   test('returns 200 for organisation', async () => {
-    const getItemOutput: Partial<GetItemCommandOutput> = {
+    const getItemOutputForOrganisation: Partial<GetItemCommandOutput> = {
       Item: {
         data: {
           M: {
@@ -75,7 +75,7 @@ describe('Request handler', () => {
         },
       },
     };
-    ddbMock.on(GetItemCommand).resolves(getItemOutput);
+    ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
     const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zakenClient: client, takenSecret: 'test' });
     expect(result.statusCode).toBe(200);

--- a/src/app/zaken/tests/samples/rollen.json
+++ b/src/app/zaken/tests/samples/rollen.json
@@ -1,0 +1,49 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "url": "/zaken/api/v1/rollen/703fb21a-88b3-45c5-b9e0-81a3909a0ce0",
+            "uuid": "703fb21a-88b3-45c5-b9e0-81a3909a0ce0",
+            "zaak": "/zaken/api/v1/zaken/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886",
+            "betrokkene": "",
+            "betrokkeneType": "niet_natuurlijk_persoon",
+            "roltype": "/catalogi/api/v1/roltypen/b9d8dd80-e163-4df7-9d91-83c76ff93f96",
+            "omschrijving": "Bezwaarmaker",
+            "omschrijvingGeneriek": "initiator",
+            "roltoelichting": "Bezwaarmaker",
+            "registratiedatum": "2023-06-13T07:45:25.012348Z",
+            "indicatieMachtiging": "",
+            "betrokkeneIdentificatie": {
+                "innNnpId": "",
+                "annIdentificatie": "65333969",
+                "statutaireNaam": "Woweb B.V.",
+                "innRechtsvorm": "",
+                "bezoekadres": "",
+                "subVerblijfBuitenland": null
+            }
+        },
+        {
+            "url": "/zaken/api/v1/rollen/841b7227-bb61-4c60-81c1-8576471160c1",
+            "uuid": "841b7227-bb61-4c60-81c1-8576471160c1",
+            "zaak": "/zaken/api/v1/zaken/3720dbc1-6a94-411e-b651-0aeb67330064",
+            "betrokkene": "",
+            "betrokkeneType": "niet_natuurlijk_persoon",
+            "roltype": "/catalogi/api/v1/roltypen/b9d8dd80-e163-4df7-9d91-83c76ff93f96",
+            "omschrijving": "Bezwaarmaker",
+            "omschrijvingGeneriek": "initiator",
+            "roltoelichting": "Bezwaarmaker",
+            "registratiedatum": "2023-03-09T10:55:53.984252Z",
+            "indicatieMachtiging": "",
+            "betrokkeneIdentificatie": {
+                "innNnpId": "",
+                "annIdentificatie": "65333969",
+                "statutaireNaam": "Woweb",
+                "innRechtsvorm": "",
+                "bezoekadres": "",
+                "subVerblijfBuitenland": null
+            }
+        }
+    ]
+}

--- a/src/app/zaken/tests/user.test.ts
+++ b/src/app/zaken/tests/user.test.ts
@@ -1,0 +1,21 @@
+import { Bsn } from '@gemeentenijmegen/utils';
+import { Person, Organisation } from '../User';
+
+describe('User types', () => {
+  test('Creating users works', async() => {
+    expect(new Person(new Bsn('900222670'))).toBeTruthy();
+    expect(new Organisation('69599084')).toBeTruthy();
+  });
+
+  test('Organisations identify as such', async() => {
+    const organisation = new Organisation('69599084');
+    expect(organisation.identifier).toBe('69599084');
+    expect(organisation.type).toBe('organisation');
+  })
+
+  test('Persons identify as such', async() => {
+    const person = new Person(new Bsn('900222670'));
+    expect(person.identifier).toBe('900222670');
+    expect(person.type).toBe('person');
+  })
+});

--- a/src/app/zaken/tests/user.test.ts
+++ b/src/app/zaken/tests/user.test.ts
@@ -11,11 +11,11 @@ describe('User types', () => {
     const organisation = new Organisation('69599084');
     expect(organisation.identifier).toBe('69599084');
     expect(organisation.type).toBe('organisation');
-  })
+  });
 
   test('Persons identify as such', async() => {
     const person = new Person(new Bsn('900222670'));
     expect(person.identifier).toBe('900222670');
     expect(person.type).toBe('person');
-  })
+  });
 });

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -9,6 +9,7 @@ import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
 import { Zaken } from './Zaken';
 import { render } from '../../shared/render';
+import { Organisation, Person, User } from './User';
 
 export async function zakenRequestHandler(
   cookies: string,
@@ -53,8 +54,8 @@ async function listZakenRequest(session: Session, client: OpenZaakClient) {
     zaken: <any>[],
   };
 
-  const bsn = new Bsn(session.getValue('bsn'));
-  const statuses = new Zaken(client, bsn);
+  const user = getUser(session);
+  const statuses = new Zaken(client, user);
   statuses.allowDomains(['APV']);
   const zaken = await statuses.list();
   data.zaken = zaken;
@@ -65,6 +66,17 @@ async function listZakenRequest(session: Session, client: OpenZaakClient) {
   return Response.html(html, 200, session.getCookie());
 }
 
+
+function getUser(session: Session) {
+  const userType = session.getValue('user_type');
+  let user: User;
+  if (userType == 'organisation') {
+    user = new Organisation(session.getValue('identifier'));
+  } else {
+    user = new Person(new Bsn(session.getValue('identifier')));
+  }
+  return user;
+}
 
 async function singleZaakRequest(session: Session, client: OpenZaakClient, zaak: string, takenSecret: string) {
 
@@ -77,8 +89,8 @@ async function singleZaakRequest(session: Session, client: OpenZaakClient, zaak:
     zaak: <any>null,
   };
 
-  const bsn = new Bsn(session.getValue('bsn'));
-  const statuses = new Zaken(client, bsn, { taken: taken(takenSecret) });
+  const user = getUser(session);
+  const statuses = new Zaken(client, user, { taken: taken(takenSecret) });
   statuses.allowDomains(['APV']);
   data.zaak = await statuses.get(zaak);
   console.debug('zaak', JSON.stringify(data.zaak));

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -7,9 +7,9 @@ import { OpenZaakClient } from './OpenZaakClient';
 import { Taken } from './Taken';
 import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
+import { Organisation, Person, User } from './User';
 import { Zaken } from './Zaken';
 import { render } from '../../shared/render';
-import { Organisation, Person, User } from './User';
 
 export async function zakenRequestHandler(
   cookies: string,


### PR DESCRIPTION
Added an abstracted User interface, which is implemented by both a Person and an organisation class.
Zaken now instead of receiving a bsn, will receive a 'user' object. This can be a person or an organisation. For organisations, we have to gather 'zaken' differently, using the 'rol' endpoint first.