### PR TITLE
chore: refactor list get

### DIFF
--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -24,17 +24,14 @@ export class Zaken {
   private resultaatTypes?: any;
   private catalogi?: any;
 
-  private user: User;
-
   private allowedDomains?: string[];
 
   private taken?: Taken;
 
   private show_documents?: boolean;
 
-  constructor(client: OpenZaakClient, user: User, config?: Config) {
+  constructor(client: OpenZaakClient, config?: Config) {
     this.client = client;
-    this.user = user;
     this.catalogiPromise = this.client.request('/catalogi/api/v1/catalogussen');
     this.zaakTypesPromise = this.client.request('/catalogi/api/v1/zaaktypen');
     this.statusTypesPromise = this.client.requestPaginated('/catalogi/api/v1/statustypen');
@@ -60,14 +57,14 @@ export class Zaken {
    *
    * @returns
    */
-  async list() {
+  async list(user: User) {
     console.timeLog('zaken status', 'awaiting metadata');
     await this.metaData();
 
     let zaken;
-    if (this.user.type == 'person') {
+    if (user.type == 'person') {
       const params = new URLSearchParams({
-        rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn: this.user.identifier,
+        rol__betrokkeneIdentificatie__natuurlijkPersoon__inpBsn: user.identifier,
         ordering: '-startdatum',
         page: '1',
       });
@@ -75,9 +72,9 @@ export class Zaken {
       // Get all zaken
       zaken = await this.client.request('/zaken/api/v1/zaken', params);
 
-    } else if (this.user.type == 'organisation') {
+    } else if (user.type == 'organisation') {
       const params = new URLSearchParams({
-        betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie: this.user.identifier,
+        betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie: user.identifier,
       });
       const roles = await this.client.request('/zaken/api/v1/rollen', params);
       const zaakUrls = roles?.results?.map((role: any) => role.zaak);
@@ -99,15 +96,15 @@ export class Zaken {
     return [];
   }
 
-  async get(zaakId: string) {
+  async get(zaakId: string, user: User) {
     console.timeLog('zaken status', 'awaiting metadata');
     await this.metaData();
     console.timeLog('zaken status', 'retrieved metadata');
     let roleUrl;
-    if (this.user.type == 'person') {
-      roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=${this.user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
+    if (user.type == 'person') {
+      roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__natuurlijkPersoon__inpBsn=${user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
     } else {
-      roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie=${this.user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
+      roleUrl = `/zaken/api/v1/rollen?betrokkeneIdentificatie__nietNatuurlijkPersoon__annIdentificatie=${user.identifier}&zaak=${this.client.baseUrl}zaken/api/v1/zaken/${zaakId}`;
     }
     const [zaak, rol] = await Promise.all([
       this.client.request(`/zaken/api/v1/zaken/${zaakId}`),

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -45,12 +45,12 @@ describe('Zaken', () => {
   const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('constructing object succeeds', async () => {
     axiosMock.onGet().reply(200, []);
-    expect(() => { new Zaken(client, new Person(new Bsn('900222670'))); }).not.toThrow();
+    expect(() => { new Zaken(client); }).not.toThrow();
   });
 
   test('zaken are processed correctly', async () => {
-    const statusResults = new Zaken(client, person);
-    const results = await statusResults.list();
+    const statusResults = new Zaken(client);
+    const results = await statusResults.list(person);
     expect(results).toStrictEqual({
       open: [
         {
@@ -94,8 +94,8 @@ describe('Zaken', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const statusResults = new Zaken(client, person);
-      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      const statusResults = new Zaken(client);
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
       expect(results).toStrictEqual(
         {
           id: 'Z23.001592',
@@ -138,8 +138,8 @@ describe('Zaken', () => {
     });
 
   test('a single zaak has several statusses, which are available in the zaak', async () => {
-    const statusResults = new Zaken(client, person, { show_documents: true });
-    const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+    const statusResults = new Zaken(client, { show_documents: true });
+    const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
     expect(results).toStrictEqual({
       id: 'Z23.001592',
       registratiedatum: '9 juni 2023',
@@ -194,8 +194,8 @@ describe('Zaken', () => {
   });
 
   test('a single zaak can have a null status', async () => {
-    const statusResults = new Zaken(client, person);
-    const results = await statusResults.get('noStatus');
+    const statusResults = new Zaken(client);
+    const results = await statusResults.get('noStatus', person);
     expect(results).toStrictEqual({
       id: 'Z23.001592',
       registratiedatum: '9 juni 2023',
@@ -237,9 +237,9 @@ describe('Filtering domains', () => {
   const person = new Person(new Bsn('900222670'));
   const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('zaken are filtered (APV)', async () => {
-    const statusResults = new Zaken(client, person);
+    const statusResults = new Zaken(client);
     statusResults.allowDomains(['APV']);
-    const results = await statusResults.list();
+    const results = await statusResults.list(person);
     expect(results).toStrictEqual({
       open: [{
         einddatum: null,
@@ -257,9 +257,9 @@ describe('Filtering domains', () => {
   });
 
   test('zaken are filtered (JZ)', async () => {
-    const statusResults = new Zaken(client, person);
+    const statusResults = new Zaken(client);
     statusResults.allowDomains(['JZ']);
-    const results = await statusResults.list();
+    const results = await statusResults.list(person);
     expect(results).toStrictEqual({
       open: [
         {
@@ -292,9 +292,9 @@ describe('Filtering domains', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const statusResults = new Zaken(client, person);
+      const statusResults = new Zaken(client);
       statusResults.allowDomains(['JZ']);
-      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
       expect(results).toStrictEqual(
         {
           id: 'Z23.001592',
@@ -337,9 +337,9 @@ describe('Filtering domains', () => {
     });
   test('a single zaak is filtered correctly (APV)',
     async () => {
-      const statusResults = new Zaken(client, person);
+      const statusResults = new Zaken(client);
       statusResults.allowDomains(['APV']);
-      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
       expect(results).toBeFalsy();
     });
 });

--- a/src/app/zaken/tests/ZakenKvk.test.ts
+++ b/src/app/zaken/tests/ZakenKvk.test.ts
@@ -40,8 +40,8 @@ describe('Zaken', () => {
   const user = new Organisation('12345678');
   const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
   test('zaken are processed correctly', async () => {
-    const statusResults = new Zaken(client, user);
-    const results = await statusResults.list();
+    const statusResults = new Zaken(client);
+    const results = await statusResults.list(user);
     expect(results).toStrictEqual({
       open: [
         {
@@ -74,8 +74,8 @@ describe('Zaken', () => {
 
   test('a single zaak is processed correctly',
     async () => {
-      const statusResults = new Zaken(client, user);
-      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
+      const statusResults = new Zaken(client);
+      const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', user);
       expect(results).toStrictEqual(
         {
           id: 'Z23.001592',

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -50,9 +50,9 @@ async function listZakenRequest(session: Session, client: OpenZaakClient) {
 
   const user = getUser(session);
 
-  const statuses = new Zaken(client, user);
+  const statuses = new Zaken(client);
   statuses.allowDomains(['APV']);
-  const zaken = await statuses.list();
+  const zaken = await statuses.list(user);
   console.timeLog('request', 'zaken received');
 
   const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
@@ -68,7 +68,6 @@ async function listZakenRequest(session: Session, client: OpenZaakClient) {
   const html = await render(data, zakenTemplate.default);
   return Response.html(html, 200, session.getCookie());
 }
-
 
 function getUser(session: Session) {
   const userType = session.getValue('user_type');
@@ -86,7 +85,7 @@ async function singleZaakRequest(session: Session, client: OpenZaakClient, zaak:
   console.timeLog('request', 'Api Client init');
 
   const user = getUser(session);
-  const statuses = new Zaken(client, user, { taken: taken(takenSecret) });
+  const statuses = new Zaken(client, { taken: taken(takenSecret) });
   statuses.allowDomains(['APV']);
 
   const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
@@ -96,7 +95,7 @@ async function singleZaakRequest(session: Session, client: OpenZaakClient, zaak:
     title: 'Zaak',
     shownav: true,
     nav: navigation.items,
-    zaak: await statuses.get(zaak),
+    zaak: await statuses.get(zaak, user),
   };
   console.debug('zaak', JSON.stringify(data.zaak));
   console.timeLog('request', 'zaak received');


### PR DESCRIPTION
To prepare for reuse/caching of metadata, each request for Zaken now requires providing the user for this request, instead of keeping this with the constructor.

This hopefully allows for moving construction of the Zaken-object to the lambda initializer, which in turn will allow for pre-loading metadat from the ZGW-api (zaaktypen, zaaktypecatalogi, etc.) which are user-independent.
