### PR TITLE
chore: Move zaken to lambda init

### DIFF
--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import * as dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
 import { OpenZaakClient } from '../OpenZaakClient';
+import { Zaken } from '../Zaken';
 import { zakenRequestHandler } from '../zakenRequestHandler';
 dotenv.config();
 
@@ -48,11 +49,12 @@ const axiosInstance = axios.create(
     },
   });
 const client = new OpenZaakClient({ baseUrl, axiosInstance });
+const zaken = new Zaken(client);
 
 describe('Request handler', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zakenClient: client, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, takenSecret: 'test' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -77,7 +79,7 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zakenClient: client, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, takenSecret: 'test' });
     expect(result.statusCode).toBe(200);
   });
 });
@@ -86,7 +88,7 @@ describe('Request handler', () => {
 describe('Request handler single zaak', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zakenClient: client, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -3,11 +3,13 @@ import { ApiGatewayV2Response, Response } from '@gemeentenijmegen/apigateway-htt
 import { AWS } from '@gemeentenijmegen/utils';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { OpenZaakClient } from './OpenZaakClient';
+import { Zaken } from './Zaken';
 import { zakenRequestHandler } from './zakenRequestHandler';
 
 const dynamoDBClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 
 let openZaakClient: OpenZaakClient | false;
+let zaken: Zaken | false;
 
 async function initSecret() {
   if (!process.env.VIP_JWT_SECRET_ARN || !process.env.VIP_TAKEN_SECRET_ARN) {
@@ -36,7 +38,11 @@ export async function handler(event: any, _context: any):Promise<ApiGatewayV2Res
     const params = parseEvent(event);
     const secrets = await initPromise;
     const zakenClient = sharedOpenZaakClient(secrets.vipSecret);
-    return await zakenRequestHandler(params.cookies, dynamoDBClient, { zakenClient, zaak: params.zaak, takenSecret: secrets.takenSecret });
+    return await zakenRequestHandler(params.cookies, dynamoDBClient, {
+      zaken: sharedZaken(zakenClient),
+      zaak: params.zaak,
+      takenSecret: secrets.takenSecret,
+    });
   } catch (err) {
     console.debug(err);
     return Response.error(500);
@@ -56,6 +62,13 @@ function sharedOpenZaakClient(secret: string): OpenZaakClient {
     });
   }
   return openZaakClient;
+}
+
+function sharedZaken(client: OpenZaakClient) {
+  if (!zaken) {
+    zaken = new Zaken(client);
+  }
+  return zaken;
 }
 
 /** Check if this function is live */


### PR DESCRIPTION
Initialize the zaken object in the lambda handler and reuse it for subsequent requests.
