### PR TITLE
fix: Show zaak id

### DIFF
--- a/src/app/zaken/templates/zaak.mustache
+++ b/src/app/zaken/templates/zaak.mustache
@@ -89,7 +89,7 @@
                 </ol>
             <h2>Details</h2>
             <p><strong>Datum aanvraag</strong>: {{registratiedatum}}</p>
-            <p><strong>Zaaknummer</strong>: {{kenmerk}}</p>
+            <p><strong>Zaaknummer</strong>: {{id}}</p>
             {{#has_documenten}}
                 <h2>Documenten</h2>
                 <ul>


### PR DESCRIPTION
Zaak id was no longer shown on the zaak-page.
