### PR TITLE
fix: metadata time log error

### DIFF
--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -236,8 +236,6 @@ export class Zaken {
 
   /** Guarantee metadata promises are resolved */
   async metaData() {
-    console.time('metadata');
-    console.timeLog('metadata', 'awaiting metadata');
     console.debug('getting metadata');
     if (!this.zaakTypes || !this.statusTypes || !this.resultaatTypes || !this.catalogi) {
       [
@@ -253,8 +251,6 @@ export class Zaken {
       ]);
     }
     console.debug('has metadata');
-    console.timeLog('metadata', 'retreived metadata');
-    console.timeEnd('metadata');
   }
 
   /**

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -66,8 +66,10 @@ function sharedOpenZaakClient(secret: string): OpenZaakClient {
 
 async function sharedZaken(client: OpenZaakClient) {
   if (!zaken) {
+    console.time('metadata');
     zaken = new Zaken(client);
     await zaken.metaData();
+    console.timeEnd('metadata');
   }
   return zaken;
 }


### PR DESCRIPTION
- Metadata collection is started during Zaken object construction. Which is first called in the main lambda file. Therefore, we time collection of the metadata there as we await the promise that guarantees completion of the metadata collection.