### PR TITLE
feat: combine inzendingen

### DIFF
--- a/src/app/zaken/Inzendingen.ts
+++ b/src/app/zaken/Inzendingen.ts
@@ -80,18 +80,20 @@ export class Inzendingen {
   }
 
   async list(user: User): Promise<{
-    id: string;
-    key: string;
-    registratiedatum: string;
-    status: string;
-  }[]> {
+    open: {
+      id: string;
+      key: string;
+      registratiedatum: string;
+      status: string;
+    }[];
+  }> {
     const params = new URLSearchParams({
       user_id: user.identifier,
       user_type: user.type,
     });
     const results = await this.request('submissions', params);
     const inzendingen = InzendingenSchema.parse(results);
-    return inzendingen.map(inzending => this.summarize(inzending));
+    return { open: inzendingen.map(inzending => this.summarize(inzending)) };
   }
 
   async get(key: string, user: User): Promise<any> {

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -1,17 +1,17 @@
 import { User } from './User';
-import { ZaakConnector } from './ZaakConnector';
+import { ZaakConnector, ZaakSummary } from './ZaakConnector';
 
 interface Config {
   zaakConnectors: ZaakConnector[];
 }
-export class ZaakAggregator {
+export class ZaakAggregator implements ZaakConnector {
   private zaakConnectors;
 
   constructor(config: Config) {
     this.zaakConnectors = config.zaakConnectors;
   }
 
-  async list(user: User) {
+  async list(user: User): Promise<ZaakSummary[]> {
     const listPromises = this.zaakConnectors.map(connector => connector.list(user));
     const results = await Promise.all(listPromises);
 

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -1,35 +1,25 @@
 import { User } from './User';
-import { Zaken } from './Zaken';
-
-// interface ZaakSummary {
-//   identifier: string;
-//   internal_id: string;
-//   registratiedatum: Date;
-//   verwachtte_einddatum?: Date;
-//   uiterlijke_einddatum?: Date;
-//   einddatum?: Date;
-//   zaak_type: string;
-//   status: string;
-//   resultaat?: string;
-// }
+import { ZaakConnector } from './ZaakConnector';
 
 interface Config {
-  zaken: Zaken;
+  zaakConnectors: ZaakConnector[];
 }
 export class ZaakAggregator {
-  private zaken;
+  private zaakConnectors;
 
   constructor(config: Config) {
-    this.zaken = config.zaken;
+    this.zaakConnectors = config.zaakConnectors;
   }
 
   async list(user: User) {
-    const zaken = await this.zaken.list(user);
-    return zaken;
+    const listPromises = this.zaakConnectors.map(connector => connector.list(user));
+    const results = await Promise.all(listPromises);
+
+    return results.flat();
   }
 
-  async get(zaakId: string, user: User) {
-    const zaak = await this.zaken.get(zaakId, user);
-    return zaak;
-  }
+  // async get(zaakId: string, user: User) {
+  //   const zaak = await this.zaken.get(zaakId, user);
+  //   return zaak;
+  // }
 }

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -1,0 +1,35 @@
+import { User } from './User';
+import { Zaken } from './Zaken';
+
+// interface ZaakSummary {
+//   identifier: string;
+//   internal_id: string;
+//   registratiedatum: Date;
+//   verwachtte_einddatum?: Date;
+//   uiterlijke_einddatum?: Date;
+//   einddatum?: Date;
+//   zaak_type: string;
+//   status: string;
+//   resultaat?: string;
+// }
+
+interface Config {
+  zaken: Zaken;
+}
+export class ZaakAggregator {
+  private zaken;
+
+  constructor(config: Config) {
+    this.zaken = config.zaken;
+  }
+
+  async list(user: User) {
+    const zaken = await this.zaken.list(user);
+    return zaken;
+  }
+
+  async get(zaakId: string, user: User) {
+    const zaak = await this.zaken.get(zaakId, user);
+    return zaak;
+  }
+}

--- a/src/app/zaken/ZaakConnector.ts
+++ b/src/app/zaken/ZaakConnector.ts
@@ -12,6 +12,7 @@ export interface ZaakSummary {
   status: string;
   resultaat?: string;
 }
+
 export interface ZaakConnector {
   list(user: User): Promise<ZaakSummary[]>;
 }

--- a/src/app/zaken/ZaakConnector.ts
+++ b/src/app/zaken/ZaakConnector.ts
@@ -1,0 +1,17 @@
+import { User } from './User';
+
+
+export interface ZaakSummary {
+  identifier: string;
+  internal_id: string;
+  registratiedatum: Date;
+  verwachtte_einddatum?: Date;
+  uiterlijke_einddatum?: Date;
+  einddatum?: Date;
+  zaak_type: string;
+  status: string;
+  resultaat?: string;
+}
+export interface ZaakConnector {
+  list(user: User): Promise<ZaakSummary[]>;
+}

--- a/src/app/zaken/ZaakFormatter.ts
+++ b/src/app/zaken/ZaakFormatter.ts
@@ -1,0 +1,31 @@
+import { ZaakSummary } from './ZaakConnector';
+
+export class ZaakFormatter {
+  static formatList(zaken: ZaakSummary[]) {
+    const sorted = zaken
+      .sort((a, b) => a.registratiedatum < b.registratiedatum ? 1 : -1)
+      .map(zaak => this.formatZaak(zaak));
+    return {
+      open: sorted.filter(zaak => zaak.resultaat),
+      gesloten: sorted.filter(zaak => !zaak.resultaat),
+    };
+  }
+
+  static formatZaak(zaak: ZaakSummary) {
+    return {
+      ...zaak,
+      registratiedatum: this.humanDate(zaak.registratiedatum),
+      verwachtte_einddatum: this.humanDate(zaak.verwachtte_einddatum),
+      uiterlijke_einddatum: this.humanDate(zaak.uiterlijke_einddatum),
+      einddatum: this.humanDate(zaak.einddatum),
+    };
+  }
+
+  /**
+   * Convert ISO 8601 datestring to something formatted like '12 september 2023'
+   */
+  private static humanDate(date: Date | undefined) {
+    if (!date) { return; }
+    return date.toLocaleDateString('nl-NL', { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+}

--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -129,12 +129,12 @@ export class Zaken implements ZaakConnector {
     console.debug('check role', rol);
     if (Number(rol?.count) >= 1) { //TODO: Omschrijven (ik gok check of persoon met bsn wel rol heeft in de zaak)
       return {
-        uuid: zaak.uuid,
-        id: zaak.identificatie,
-        registratiedatum: this.humanDate(zaak.registratiedatum),
-        verwachtte_einddatum: this.humanDate(zaak.einddatumGepland),
-        uiterlijke_einddatum: this.humanDate(zaak.uiterlijkeEinddatumAfdoening),
-        einddatum: zaak.einddatum ? this.humanDate(zaak.einddatum) : null,
+        internal_id: zaak.uuid,
+        identifier: zaak.identificatie,
+        registratiedatum: new Date(zaak.registratiedatum),
+        verwachtte_einddatum: new Date(zaak.einddatumGepland),
+        uiterlijke_einddatum: new Date(zaak.uiterlijkeEinddatumAfdoening),
+        einddatum: zaak.einddatum ? new Date(zaak.einddatum) : undefined,
         zaak_type: zaakType?.omschrijving,
         status_list: this.statusTypesForZaakType(zaakType, status),
         status: this.statusTypes.results.find((type: any) => type.url == status?.statustype)?.omschrijving || null,
@@ -225,14 +225,6 @@ export class Zaken implements ZaakConnector {
       zaak_summaries.push(summary);
     }
     return zaak_summaries;
-  }
-
-  /**
-   * Convert ISO 8601 datestring to something formatted like '12 september 2023'
-   */
-  private humanDate(dateString: string) {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('nl-NL', { year: 'numeric', month: 'long', day: 'numeric' });
   }
 
   /** Guarantee metadata promises are resolved */

--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -99,7 +99,10 @@ export class Zaken {
       return this.summarizeZaken(zaken, statussen, resultaten);
     }
     console.timeEnd('list zaken');
-    return [];
+    return {
+      open: [],
+      gesloten: [],
+    };
   }
 
   async get(zaakId: string, user: User) {

--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -1,6 +1,7 @@
 import { OpenZaakClient } from './OpenZaakClient';
 import { Taken } from './Taken';
 import { User } from './User';
+import { ZaakConnector, ZaakSummary } from './ZaakConnector';
 
 interface Config {
   taken?: Taken;
@@ -12,7 +13,7 @@ interface Config {
   show_documents?: boolean;
 }
 
-export class Zaken {
+export class Zaken implements ZaakConnector {
   private client: OpenZaakClient;
   private statusTypesPromise: Promise<any>;
   private zaakTypesPromise: Promise<any>;
@@ -99,10 +100,7 @@ export class Zaken {
       return this.summarizeZaken(zaken, statussen, resultaten);
     }
     console.timeEnd('list zaken');
-    return {
-      open: [],
-      gesloten: [],
-    };
+    return [];
   }
 
   async get(zaakId: string, user: User) {
@@ -195,8 +193,8 @@ export class Zaken {
     ]);
   }
 
-  private summarizeZaken(zaken: any, statussen: any[], resultaten: any[]) {
-    const zaak_summaries: { open: any[]; gesloten: any[] } = { open: [], gesloten: [] };
+  private summarizeZaken(zaken: any, statussen: any[], resultaten: any[]): ZaakSummary[] {
+    const zaak_summaries = [];
     for (const zaak of zaken.results) {
       // Only process zaken in allowed catalogi
       if (!this.zaakTypeInAllowedCatalogus(zaak.zaaktype)) { continue; }
@@ -213,22 +211,18 @@ export class Zaken {
         resultaat_type = this.resultaatTypes.results.find((type: any) => type.url == resultaat.resultaattype)?.omschrijving;
       }
       const summary = {
-        id: zaak.identificatie,
-        uuid: zaak.uuid,
-        registratiedatum: this.humanDate(zaak.registratiedatum),
-        verwachtte_einddatum: this.humanDate(zaak.einddatumGepland),
-        uiterlijke_einddatum: this.humanDate(zaak.uiterlijkeEinddatumAfdoening),
-        einddatum: zaak.einddatum ? this.humanDate(zaak.einddatum) : null,
+        identifier: zaak.identificatie,
+        internal_id: zaak.uuid,
+        registratiedatum: new Date(zaak.registratiedatum),
+        verwachtte_einddatum: new Date(zaak.einddatumGepland),
+        uiterlijke_einddatum: new Date(zaak.uiterlijkeEinddatumAfdoening),
+        einddatum: zaak.einddatum ? new Date(zaak.einddatum) : undefined,
         zaak_type: zaaktype,
         status: status_type,
         resultaat: resultaat_type,
       };
       console.debug('summary', summary);
-      if (resultaat) {
-        zaak_summaries.gesloten.push(summary);
-      } else {
-        zaak_summaries.open.push(summary);
-      }
+      zaak_summaries.push(summary);
     }
     return zaak_summaries;
   }

--- a/src/app/zaken/templates/zaken.mustache
+++ b/src/app/zaken/templates/zaken.mustache
@@ -47,7 +47,7 @@
                         </div>
                         <div class="denhaag-card__actions">
                             <div class="denhaag-card__date-wrapper"><time datetime="2020-01-21T00:00:00.000Z">{{registratiedatum}}</time></div><a
-                            href="/zaken/{{uuid}}" class="denhaag-card__action-link"><svg width="1em" height="1em" viewBox="0 0 24 24" fill="none"
+                            href="/zaken/{{internal_id}}" class="denhaag-card__action-link"><svg width="1em" height="1em" viewBox="0 0 24 24" fill="none"
                                 xmlns="http://www.w3.org/2000/svg" class="denhaag-icon denhaag-card__arrow-icon" focusable="false"
                                 aria-hidden="true" shape-rendering="auto">
                                 <path
@@ -77,7 +77,7 @@
                         </div>
                         <div class="denhaag-card__actions">
                             <div class="denhaag-card__date-wrapper"><time datetime="2020-01-21T00:00:00.000Z">{{registratiedatum}}</time></div><a
-                            href="/zaken/{{uuid}}" class="denhaag-card__action-link"><svg width="1em" height="1em" viewBox="0 0 24 24" fill="none"
+                            href="/zaken/{{internal_id}}" class="denhaag-card__action-link"><svg width="1em" height="1em" viewBox="0 0 24 24" fill="none"
                                 xmlns="http://www.w3.org/2000/svg" class="denhaag-icon denhaag-card__arrow-icon" focusable="false"
                                 aria-hidden="true" shape-rendering="auto">
                                 <path

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -51,45 +51,41 @@ describe('Zaken', () => {
   test('zaken are processed correctly', async () => {
     const statusResults = new Zaken(client);
     const results = await statusResults.list(person);
-    expect(results).toStrictEqual({
-      open: [
-        {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
-          resultaat: null,
-          status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
-          zaak_type: 'Bezwaar',
-        },
-        {
-          einddatum: null,
-          id: 'Z23.001719',
-          registratiedatum: '21 september 2023',
-          resultaat: null,
-          status: null,
-          uiterlijke_einddatum: '20 september 2024',
-          uuid: '30009319-395f-491f-be0e-24c0e0d04a75',
-          verwachtte_einddatum: '20 september 2024',
-          zaak_type: 'Bingo',
-        },
-      ],
-      gesloten: [
-        {
-          id: 'Z23.001438',
-          registratiedatum: '30 maart 2023',
-          einddatum: '28 maart 2023',
-          verwachtte_einddatum: '20 juni 2023',
-          uiterlijke_einddatum: '11 juni 2023',
-          resultaat: 'Ingetrokken na BIA',
-          status: 'In behandeling',
-          uuid: '3720dbc1-6a94-411e-b651-0aeb67330064',
-          zaak_type: 'Klacht',
-        },
-      ],
-    });
+    expect(results).toStrictEqual([
+      {
+        identifier: 'Z23.001592',
+        registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+        einddatum: undefined,
+        uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+        resultaat: null,
+        status: 'In behandeling',
+        internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+        zaak_type: 'Bezwaar',
+      },
+      {
+        einddatum: undefined,
+        identifier: 'Z23.001719',
+        registratiedatum: new Date('2023-09-21T00:00:00.000Z'),
+        resultaat: null,
+        status: null,
+        uiterlijke_einddatum: new Date('2024-09-20T00:00:00.000Z'),
+        internal_id: '30009319-395f-491f-be0e-24c0e0d04a75',
+        verwachtte_einddatum: new Date('2024-09-20T00:00:00.000Z'),
+        zaak_type: 'Bingo',
+      },
+      {
+        identifier: 'Z23.001438',
+        registratiedatum: new Date('2023-03-30T00:00:00.000Z'),
+        einddatum: new Date('2023-03-28T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-06-20T00:00:00.000Z'),
+        uiterlijke_einddatum: new Date('2023-06-11T00:00:00.000Z'),
+        resultaat: 'Ingetrokken na BIA',
+        status: 'In behandeling',
+        internal_id: '3720dbc1-6a94-411e-b651-0aeb67330064',
+        zaak_type: 'Klacht',
+      },
+    ]);
   });
 
   test('a single zaak is processed correctly',
@@ -98,14 +94,14 @@ describe('Zaken', () => {
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
       expect(results).toStrictEqual(
         {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
+          identifier: 'Z23.001592',
+          registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+          verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+          einddatum: undefined,
+          uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
           resultaat: null,
           status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+          internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
           zaak_type: 'Bezwaar',
           status_list: [
             {
@@ -141,11 +137,11 @@ describe('Zaken', () => {
     const statusResults = new Zaken(client, { show_documents: true });
     const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
     expect(results).toStrictEqual({
-      id: 'Z23.001592',
-      registratiedatum: '9 juni 2023',
-      verwachtte_einddatum: '1 september 2023',
-      uiterlijke_einddatum: '11 oktober 2023',
-      einddatum: null,
+      identifier: 'Z23.001592',
+      registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+      verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+      uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+      einddatum: undefined,
       resultaat: null,
       status: 'In behandeling',
       status_list: [
@@ -171,7 +167,7 @@ describe('Zaken', () => {
           volgnummer: 3,
         },
       ],
-      uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+      internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
       zaak_type: 'Bezwaar',
       has_documenten: true,
       documenten: [
@@ -197,15 +193,15 @@ describe('Zaken', () => {
     const statusResults = new Zaken(client);
     const results = await statusResults.get('noStatus', person);
     expect(results).toStrictEqual({
-      id: 'Z23.001592',
-      registratiedatum: '9 juni 2023',
-      verwachtte_einddatum: '1 september 2023',
-      uiterlijke_einddatum: '11 oktober 2023',
-      einddatum: null,
+      identifier: 'Z23.001592',
+      registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+      verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+      uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+      einddatum: undefined,
       resultaat: null,
       status: null,
       status_list: null,
-      uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+      internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
       zaak_type: 'Bezwaar',
       has_documenten: false,
       documenten: null,
@@ -240,54 +236,47 @@ describe('Filtering domains', () => {
     const statusResults = new Zaken(client);
     statusResults.allowDomains(['APV']);
     const results = await statusResults.list(person);
-    expect(results).toStrictEqual({
-      open: [{
-        einddatum: null,
-        id: 'Z23.001719',
-        registratiedatum: '21 september 2023',
-        resultaat: null,
-        status: null,
-        uiterlijke_einddatum: '20 september 2024',
-        uuid: '30009319-395f-491f-be0e-24c0e0d04a75',
-        verwachtte_einddatum: '20 september 2024',
-        zaak_type: 'Bingo',
-      }],
-      gesloten: [],
-    });
+    expect(results).toStrictEqual([{
+      einddatum: undefined,
+      identifier: 'Z23.001719',
+      registratiedatum: new Date('2023-09-21T00:00:00.000Z'),
+      resultaat: null,
+      status: null,
+      uiterlijke_einddatum: new Date('2024-09-20T00:00:00.000Z'),
+      internal_id: '30009319-395f-491f-be0e-24c0e0d04a75',
+      verwachtte_einddatum: new Date('2024-09-20T00:00:00.000Z'),
+      zaak_type: 'Bingo',
+    }]);
   });
 
   test('zaken are filtered (JZ)', async () => {
     const statusResults = new Zaken(client);
     statusResults.allowDomains(['JZ']);
     const results = await statusResults.list(person);
-    expect(results).toStrictEqual({
-      open: [
-        {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
-          resultaat: null,
-          status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
-          zaak_type: 'Bezwaar',
-        },
-      ],
-      gesloten: [
-        {
-          id: 'Z23.001438',
-          registratiedatum: '30 maart 2023',
-          einddatum: '28 maart 2023',
-          verwachtte_einddatum: '20 juni 2023',
-          uiterlijke_einddatum: '11 juni 2023',
-          resultaat: 'Ingetrokken na BIA',
-          status: 'In behandeling',
-          uuid: '3720dbc1-6a94-411e-b651-0aeb67330064',
-          zaak_type: 'Klacht',
-        },
-      ],
-    });
+    expect(results).toStrictEqual([
+      {
+        identifier: 'Z23.001592',
+        registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+        einddatum: undefined,
+        uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+        resultaat: null,
+        status: 'In behandeling',
+        internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+        zaak_type: 'Bezwaar',
+      },
+      {
+        identifier: 'Z23.001438',
+        registratiedatum: new Date('2023-03-30T00:00:00.000Z'),
+        einddatum: new Date('2023-03-28T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-06-20T00:00:00.000Z'),
+        uiterlijke_einddatum: new Date('2023-06-11T00:00:00.000Z'),
+        resultaat: 'Ingetrokken na BIA',
+        status: 'In behandeling',
+        internal_id: '3720dbc1-6a94-411e-b651-0aeb67330064',
+        zaak_type: 'Klacht',
+      },
+    ]);
   });
 
   test('a single zaak is processed correctly',
@@ -297,14 +286,14 @@ describe('Filtering domains', () => {
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', person);
       expect(results).toStrictEqual(
         {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
+          identifier: 'Z23.001592',
+          registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+          verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+          einddatum: undefined,
+          uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
           resultaat: null,
           status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+          internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
           zaak_type: 'Bezwaar',
           status_list: [
             {

--- a/src/app/zaken/tests/ZakenKvk.test.ts
+++ b/src/app/zaken/tests/ZakenKvk.test.ts
@@ -42,34 +42,32 @@ describe('Zaken', () => {
   test('zaken are processed correctly', async () => {
     const statusResults = new Zaken(client);
     const results = await statusResults.list(user);
-    expect(results).toStrictEqual({
-      open: [
-        {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
-          resultaat: null,
-          status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
-          zaak_type: 'Bezwaar',
-        },
-      ],
-      gesloten: [
-        {
-          id: 'Z23.001438',
-          registratiedatum: '30 maart 2023',
-          einddatum: '28 maart 2023',
-          verwachtte_einddatum: '20 juni 2023',
-          uiterlijke_einddatum: '11 juni 2023',
-          resultaat: 'Ingetrokken na BIA',
-          status: 'In behandeling',
-          uuid: '3720dbc1-6a94-411e-b651-0aeb67330064',
-          zaak_type: 'Klacht',
-        },
-      ],
-    });
+    expect(results).toStrictEqual([
+      {
+        identifier: 'Z23.001592',
+        registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+        einddatum: undefined,
+        uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+        resultaat: null,
+        status: 'In behandeling',
+        internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+        zaak_type: 'Bezwaar',
+      },
+
+      {
+        identifier: 'Z23.001438',
+        registratiedatum: new Date('2023-03-30T00:00:00.000Z'),
+        einddatum: new Date('2023-03-28T00:00:00.000Z'),
+        verwachtte_einddatum: new Date('2023-06-20T00:00:00.000Z'),
+        uiterlijke_einddatum: new Date('2023-06-11T00:00:00.000Z'),
+        resultaat: 'Ingetrokken na BIA',
+        status: 'In behandeling',
+        internal_id: '3720dbc1-6a94-411e-b651-0aeb67330064',
+        zaak_type: 'Klacht',
+      },
+    ],
+    );
   });
 
   test('a single zaak is processed correctly',
@@ -78,14 +76,14 @@ describe('Zaken', () => {
       const results = await statusResults.get('5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', user);
       expect(results).toStrictEqual(
         {
-          id: 'Z23.001592',
-          registratiedatum: '9 juni 2023',
-          verwachtte_einddatum: '1 september 2023',
-          einddatum: null,
-          uiterlijke_einddatum: '11 oktober 2023',
+          identifier: 'Z23.001592',
+          registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+          verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+          einddatum: undefined,
+          uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
           resultaat: null,
           status: 'In behandeling',
-          uuid: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+          internal_id: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
           zaak_type: 'Bezwaar',
           status_list: [
             {

--- a/src/app/zaken/tests/inzendingen.test.ts
+++ b/src/app/zaken/tests/inzendingen.test.ts
@@ -19,8 +19,8 @@ const person = new Person(new Bsn('900222670'));
 describe('Inzendingen from submission storage', () => {
   test('Getting a list of submissions', async() => {
     const submissions = await inzendingen.list(person);
-    expect(submissions.open).toHaveLength(23);
-    expect(submissions.open.pop()).toHaveProperty('id');
+    expect(submissions).toHaveLength(23);
+    expect(submissions.pop()).toHaveProperty('identifier');
   });
 
   test('Getting a single submission', async() => {

--- a/src/app/zaken/tests/inzendingen.test.ts
+++ b/src/app/zaken/tests/inzendingen.test.ts
@@ -19,8 +19,8 @@ const person = new Person(new Bsn('900222670'));
 describe('Inzendingen from submission storage', () => {
   test('Getting a list of submissions', async() => {
     const submissions = await inzendingen.list(person);
-    expect(submissions).toHaveLength(23);
-    expect(submissions.pop()).toHaveProperty('id');
+    expect(submissions.open).toHaveLength(23);
+    expect(submissions.open.pop()).toHaveProperty('id');
   });
 
   test('Getting a single submission', async() => {

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -6,9 +6,48 @@ import axios from 'axios';
 import * as dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
 import { OpenZaakClient } from '../OpenZaakClient';
+import { ZaakSummary } from '../ZaakConnector';
 import { Zaken } from '../Zaken';
 import { zakenRequestHandler } from '../zakenRequestHandler';
 dotenv.config();
+
+const sampleDate = new Date();
+const mockedZakenList: ZaakSummary[] = [
+  {
+    identifier: '123',
+    internal_id: 'zaak/hiereenuuid',
+    registratiedatum: sampleDate,
+    verwachtte_einddatum: sampleDate,
+    uiterlijke_einddatum: sampleDate,
+    einddatum: sampleDate,
+    zaak_type: 'zaaktype1',
+    status: 'open',
+    resultaat: 'geen',
+  },
+];
+const mockedZaak = {
+  identifier: '123',
+  internal_id: 'zaak/hiereenuuid',
+  registratiedatum: sampleDate,
+  verwachtte_einddatum: sampleDate,
+  uiterlijke_einddatum: sampleDate,
+  einddatum: sampleDate,
+  zaak_type: 'zaaktype1',
+  status: 'open',
+  resultaat: 'geen',
+};
+
+jest.mock('../Zaken', () => {
+  return {
+    Zaken: jest.fn(() => {
+      return {
+        allowDomains: jest.fn(),
+        list: jest.fn().mockResolvedValue(mockedZakenList),
+        get: jest.fn().mockResolvedValue(mockedZaak),
+      };
+    }),
+  };
+});
 
 const ddbMock = mockClient(DynamoDBClient);
 const getItemOutput: Partial<GetItemCommandOutput> = {

--- a/src/app/zaken/tests/zaakaggregator.test.ts
+++ b/src/app/zaken/tests/zaakaggregator.test.ts
@@ -3,25 +3,48 @@ import axios from 'axios';
 import { OpenZaakClient } from '../OpenZaakClient';
 import { Person } from '../User';
 import { ZaakAggregator } from '../ZaakAggregator';
+import { ZaakSummary } from '../ZaakConnector';
 import { Zaken } from '../Zaken';
 
 const sampleDate = new Date();
-const mockedZakenList = {
-  open: [
-    {
-      identifier: '123',
-      internal_id: 'hiereneuuid',
-      registratiedatum: sampleDate,
-      verwachtte_einddatum: sampleDate,
-      uiterlijke_einddatum: sampleDate,
-      einddatum: sampleDate,
-      zaak_type: 'zaaktype1',
-      status: 'gesloten',
-      resultaat: 'geen',
-    },
-  ],
-  gesloten: [],
-};
+const mockedZakenList: ZaakSummary[] = [
+  {
+    identifier: '123',
+    internal_id: 'zaak/hiereenuuid',
+    registratiedatum: sampleDate,
+    verwachtte_einddatum: sampleDate,
+    uiterlijke_einddatum: sampleDate,
+    einddatum: sampleDate,
+    zaak_type: 'zaaktype1',
+    status: 'open',
+    resultaat: 'geen',
+  },
+];
+
+const mockedInzendingenList: ZaakSummary[] = [
+  {
+    identifier: '234',
+    internal_id: 'inzending/234',
+    registratiedatum: sampleDate,
+    zaak_type: 'inzending',
+    status: 'ontvangen',
+  },
+];
+
+const mockedAggregatedZaken = [
+  {
+    identifier: '123',
+    internal_id: 'zaak/hiereenuuid',
+    registratiedatum: sampleDate,
+    verwachtte_einddatum: sampleDate,
+    uiterlijke_einddatum: sampleDate,
+    einddatum: sampleDate,
+    zaak_type: 'zaaktype1',
+    status: 'open',
+    resultaat: 'geen',
+  },
+];
+
 jest.mock('../Zaken', () => {
   return {
     Zaken: jest.fn(() => {
@@ -30,17 +53,24 @@ jest.mock('../Zaken', () => {
       };
     }),
   };
+});
 
+jest.mock('../Inzendingen', () => {
+  return {
+    Zaken: jest.fn(() => {
+      return {
+        list: jest.fn().mockResolvedValue(mockedInzendingenList),
+      };
+    }),
+  };
+});
 
-},
-
-);
 let baseUrl = new URL('http://localhost');
 const person = new Person(new Bsn('900222670'));
 const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
 describe('Zaakaggregator returns combined zaken', () => {
   test('Zaakaggregator results in summaries useful for listing', async() => {
-    const aggregator = new ZaakAggregator({ zaken: new Zaken(client) });
-    expect(await aggregator.list(person)).toBe(mockedZakenList);
+    const aggregator = new ZaakAggregator({ zaakConnectors: [new Zaken(client)] });
+    expect(await aggregator.list(person)).toStrictEqual(mockedAggregatedZaken);
   });
 });

--- a/src/app/zaken/tests/zaakaggregator.test.ts
+++ b/src/app/zaken/tests/zaakaggregator.test.ts
@@ -1,0 +1,46 @@
+import { Bsn } from '@gemeentenijmegen/utils';
+import axios from 'axios';
+import { OpenZaakClient } from '../OpenZaakClient';
+import { Person } from '../User';
+import { ZaakAggregator } from '../ZaakAggregator';
+import { Zaken } from '../Zaken';
+
+const sampleDate = new Date();
+const mockedZakenList = {
+  open: [
+    {
+      identifier: '123',
+      internal_id: 'hiereneuuid',
+      registratiedatum: sampleDate,
+      verwachtte_einddatum: sampleDate,
+      uiterlijke_einddatum: sampleDate,
+      einddatum: sampleDate,
+      zaak_type: 'zaaktype1',
+      status: 'gesloten',
+      resultaat: 'geen',
+    },
+  ],
+  gesloten: [],
+};
+jest.mock('../Zaken', () => {
+  return {
+    Zaken: jest.fn(() => {
+      return {
+        list: jest.fn().mockResolvedValue(mockedZakenList),
+      };
+    }),
+  };
+
+
+},
+
+);
+let baseUrl = new URL('http://localhost');
+const person = new Person(new Bsn('900222670'));
+const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
+describe('Zaakaggregator returns combined zaken', () => {
+  test('Zaakaggregator results in summaries useful for listing', async() => {
+    const aggregator = new ZaakAggregator({ zaken: new Zaken(client) });
+    expect(await aggregator.list(person)).toBe(mockedZakenList);
+  });
+});

--- a/src/app/zaken/tests/zaakaggregator.test.ts
+++ b/src/app/zaken/tests/zaakaggregator.test.ts
@@ -1,5 +1,6 @@
 import { Bsn } from '@gemeentenijmegen/utils';
 import axios from 'axios';
+import { Inzendingen } from '../Inzendingen';
 import { OpenZaakClient } from '../OpenZaakClient';
 import { Person } from '../User';
 import { ZaakAggregator } from '../ZaakAggregator';
@@ -43,6 +44,13 @@ const mockedAggregatedZaken = [
     status: 'open',
     resultaat: 'geen',
   },
+  {
+    identifier: '234',
+    internal_id: 'inzending/234',
+    registratiedatum: sampleDate,
+    zaak_type: 'inzending',
+    status: 'ontvangen',
+  },
 ];
 
 jest.mock('../Zaken', () => {
@@ -57,7 +65,7 @@ jest.mock('../Zaken', () => {
 
 jest.mock('../Inzendingen', () => {
   return {
-    Zaken: jest.fn(() => {
+    Inzendingen: jest.fn(() => {
       return {
         list: jest.fn().mockResolvedValue(mockedInzendingenList),
       };
@@ -68,9 +76,16 @@ jest.mock('../Inzendingen', () => {
 let baseUrl = new URL('http://localhost');
 const person = new Person(new Bsn('900222670'));
 const client = new OpenZaakClient({ baseUrl, axiosInstance: axios });
+const inzendingen = new Inzendingen({ baseUrl: 'https://example.com', accessKey: 'test-access-key' });
+const zaken = new Zaken(client);
 describe('Zaakaggregator returns combined zaken', () => {
   test('Zaakaggregator results in summaries useful for listing', async() => {
-    const aggregator = new ZaakAggregator({ zaakConnectors: [new Zaken(client)] });
+    const aggregator = new ZaakAggregator({
+      zaakConnectors: [
+        zaken,
+        inzendingen,
+      ],
+    });
     expect(await aggregator.list(person)).toStrictEqual(mockedAggregatedZaken);
   });
 });


### PR DESCRIPTION
It's now possible to aggregate zaken from several connectors. Multiple
ZGW or 'other' connections are possible. The ZaakAggregator class is
passed ZaakConnector-compatible connectors and aggregates received
information.

The ZaakFormatter then sorts and formats all received information to be
compatible with the frontend. (Sorting by date, binning by open/closed).