### PR TITLE
feat: paginated requests

### DIFF
--- a/src/app/zaken/OpenZaakClient.ts
+++ b/src/app/zaken/OpenZaakClient.ts
@@ -60,7 +60,7 @@ export class OpenZaakClient {
     return token;
   }
 
-  async request(endpoint: string, params?: URLSearchParams): Promise<any> {
+  async requestSingle(endpoint: string, params?: URLSearchParams): Promise<any> {
     const paramString = params ? `?${params}` : '';
     const url =`${endpoint}${paramString}`;
     try {
@@ -91,11 +91,11 @@ export class OpenZaakClient {
     }
   }
 
-  async requestPaginated(endpoint: string, params?: URLSearchParams): Promise<any> {
-    const data = await this.request(endpoint, params);
+  async request(endpoint: string, params?: URLSearchParams): Promise<any> {
+    const data = await this.requestSingle(endpoint, params);
     if (data.next) {
       // request next page
-      const page = await this.requestPaginated(data.next);
+      const page = await this.request(data.next);
       if (page.results) {
         data.results = [...data.results, ...page.results];
       }

--- a/src/app/zaken/Zaken.ts
+++ b/src/app/zaken/Zaken.ts
@@ -43,7 +43,7 @@ export class Zaken implements ZaakConnector {
     // Cache metadata
     this.catalogiPromise = this.client.request('/catalogi/api/v1/catalogussen');
     this.zaakTypesPromise = this.client.request('/catalogi/api/v1/zaaktypen');
-    this.statusTypesPromise = this.client.requestPaginated('/catalogi/api/v1/statustypen');
+    this.statusTypesPromise = this.client.request('/catalogi/api/v1/statustypen');
     this.resultaatTypesPromise = this.client.request('/catalogi/api/v1/resultaattypen');
   }
   download(_zaakId: string, _file: string, _user: User): Promise<{ downloadUrl: string }> {

--- a/src/app/zaken/tests/openZaakClient.test.ts
+++ b/src/app/zaken/tests/openZaakClient.test.ts
@@ -178,7 +178,7 @@ describe('pagination tests', () => {
     axiosMock.onGet('/catalogi/api/v1/statustypen?page=3').reply(200, statusTypenPage3);
 
     const client = new OpenZaakClient({ baseUrl, axiosInstance });
-    const statustypen = await client.requestPaginated('/catalogi/api/v1/statustypen');
+    const statustypen = await client.request('/catalogi/api/v1/statustypen');
     expect(statustypen.results).toHaveLength(6);
   });
 });


### PR DESCRIPTION
Al requests by the openzaakclient are now pagination-aware. Each request checks if there is a 'data.next' value, and will call the endpoint from that value, merging the results. This was only used for zaaktypes.

Fixes #397