### PR TITLE
feat: Add 'behandelaars' to zaakinformatie

### DIFF
--- a/src/app/zaken/ZaakConnector.ts
+++ b/src/app/zaken/ZaakConnector.ts
@@ -26,6 +26,7 @@ export interface SingleZaak {
   resultaat?: string;
   documenten?: any[];
   taken?: any[];
+  behandelaars?: string[];
 }
 
 export interface ZaakConnector {

--- a/src/app/zaken/ZaakFormatter.ts
+++ b/src/app/zaken/ZaakFormatter.ts
@@ -32,6 +32,8 @@ export class ZaakFormatter {
       documenten: zaak.documenten?.sort(this.sortDocuments),
       has_taken: zaak.taken && zaak.taken?.length > 0 ? true : false,
       has_statuses: zaak.status_list && zaak.status_list?.length > 0 ? true : false,
+      behandelaars: zaak.behandelaars?.sort((a, b) => a < b ? -1 : 1).join(', '),
+      has_behandelaars: zaak.behandelaars && zaak.behandelaars.length > 0 ? true : false,
     };
   }
 

--- a/src/app/zaken/templates/zaak.mustache
+++ b/src/app/zaken/templates/zaak.mustache
@@ -95,6 +95,12 @@
                 <dd>{{registratiedatum}}</dd>
                 <dt>Zaaknummer</dt>
                 <dd>{{identifier}}</dd>
+                {{#has_behandelaars}}
+                <dt>Behandelaars</dt>
+                {{#behandelaars}}
+                <dd>{{.}}</dd>
+                {{/behandelaars}}
+                {{/has_behandelaars}}
             </dl>
             {{#has_documenten}}
                 <h2>Documenten</h2>

--- a/src/app/zaken/tests/Zaken.test.ts
+++ b/src/app/zaken/tests/Zaken.test.ts
@@ -131,6 +131,7 @@ describe('Zaken', () => {
           ],
           documenten: [],
           taken: null,
+          behandelaars: [],
         });
     });
 
@@ -186,6 +187,7 @@ describe('Zaken', () => {
         },
       ],
       taken: null,
+      behandelaars: [],
     });
   });
 
@@ -206,6 +208,7 @@ describe('Zaken', () => {
       zaak_type: 'Bezwaar',
       documenten: [],
       taken: null,
+      behandelaars: [],
     });
   });
 
@@ -322,6 +325,7 @@ describe('Filtering domains', () => {
           ],
           documenten: [],
           taken: null,
+          behandelaars: [],
         });
     });
   test('a single zaak is filtered correctly (APV)',

--- a/src/app/zaken/tests/ZakenKvk.test.ts
+++ b/src/app/zaken/tests/ZakenKvk.test.ts
@@ -111,6 +111,7 @@ describe('Zaken', () => {
           ],
           documenten: [],
           taken: null,
+          behandelaars: undefined,
         });
     });
 

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -42,8 +42,9 @@ const mockedZaak = {
   verwachtte_einddatum: sampleDate,
   uiterlijke_einddatum: sampleDate,
   einddatum: sampleDate,
-  zaak_type: 'zaaktype2',
+  zaak_type: 'zaaktype 2',
   status: 'open',
+  behandelaars: ['Jan Jansen', 'Andries Fietst'],
 };
 
 const mockedInzendingenList: ZaakSummary[] = [

--- a/src/app/zaken/tests/zaakformatter.test.ts
+++ b/src/app/zaken/tests/zaakformatter.test.ts
@@ -1,0 +1,24 @@
+import { SingleZaak } from '../ZaakConnector';
+import { ZaakFormatter } from '../ZaakFormatter';
+
+describe('Zaakformatter can format single zaak', () => {
+  test('Sorting behandelaars works', async () => {
+    const zaak: SingleZaak = {
+      identifier: 'Z23.001592',
+      registratiedatum: new Date('2023-06-09T00:00:00.000Z'),
+      verwachtte_einddatum: new Date('2023-09-01T00:00:00.000Z'),
+      uiterlijke_einddatum: new Date('2023-10-11T00:00:00.000Z'),
+      einddatum: undefined,
+      resultaat: undefined,
+      status: 'test',
+      status_list: undefined,
+      internal_id: 'test/5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886',
+      zaak_type: 'Bezwaar',
+      documenten: [],
+      taken: undefined,
+      behandelaars: ['Piet Pietersen', 'Antoon Andriessen'],
+    };
+
+    expect(ZaakFormatter.formatZaak(zaak).behandelaars).toBe('Antoon Andriessen, Piet Pietersen');
+  });
+});


### PR DESCRIPTION
For zaakdetails, the roles can now contain 'behandelaars'. These may or may not exists for any particular 'zaak'. This commit adds them to the zaakinformatie, and formats them for the template.

Fixes #407