### PR TITLE
chore: refactor zaken

### DIFF
--- a/src/app/zaken/Taken.ts
+++ b/src/app/zaken/Taken.ts
@@ -3,7 +3,13 @@ import { OpenZaakClient } from './OpenZaakClient';
 
 export class Taken {
 
-  static takenFromSecret(secret: string) {
+  /**
+   * Create a new Taken object using the provided API key.
+   *
+   * @param key The api token for openzaak client
+   * @returns Taken object
+   */
+  static withApiKey(key: string) {
     if (process.env.USE_TAKEN !== 'true') {
       return false;
     }
@@ -14,7 +20,7 @@ export class Taken {
       {
         baseURL: process.env.VIP_TOKEN_BASE_URL,
         headers: {
-          Authorization: 'Token ' + secret,
+          Authorization: 'Token ' + key,
         },
       },
     );

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -11,6 +11,10 @@ export class ZaakAggregator {
     this.zaakConnectors = config.zaakConnectors;
   }
 
+  public addConnector(name: string, connector: ZaakConnector) {
+    this.zaakConnectors[name] = connector;
+  }
+
   async list(user: User): Promise<ZaakSummary[]> {
     const listPromises = Object.values(this.zaakConnectors)
       .map(connector => connector.list(user));

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -7,6 +7,7 @@ import * as dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
 import { Inzendingen } from '../Inzendingen';
 import { OpenZaakClient } from '../OpenZaakClient';
+import { ZaakAggregator } from '../ZaakAggregator';
 import { ZaakSummary } from '../ZaakConnector';
 import { Zaken } from '../Zaken';
 import { zakenRequestHandler } from '../zakenRequestHandler';
@@ -123,11 +124,13 @@ const axiosInstance = axios.create(
 const client = new OpenZaakClient({ baseUrl, axiosInstance });
 const zaken = new Zaken(client, { zaakConnectorId: 'test' });
 const inzendingen = new Inzendingen({ baseUrl: 'https://localhost', accessKey: 'test' });
+const zaakAggregator = new ZaakAggregator({ zaakConnectors: { inzendingen, zaken } });
+const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaken } });
 
 describe('Request handler', () => {
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, inzendingen, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, inzendingen, zaakAggregator, takenSecret: 'test' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -152,7 +155,7 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, takenSecret: 'test' });
     expect(result.statusCode).toBe(200);
   });
 });
@@ -161,7 +164,7 @@ describe('Request handler', () => {
 describe('Request handler single zaak', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test', zaakConnectorId: 'zaak' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test', zaakConnectorId: 'zaak' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -34,7 +34,7 @@ export async function zakenRequestHandler(
   await session.init();
 
   if (config.takenSecret) {
-    config.zaken.setTaken(Taken.takenFromSecret(config.takenSecret));
+    config.zaken.setTaken(Taken.withApiKey(config.takenSecret));
   }
 
   console.timeLog('request', 'init session');

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -20,6 +20,7 @@ export async function zakenRequestHandler(
   config: {
     zaken: Zaken;
     inzendingen?: Inzendingen;
+    zaakAggregator: ZaakAggregator;
     zaak?: string;
     file?: string;
     takenSecret?: string;
@@ -58,7 +59,7 @@ export async function zakenRequestHandler(
           throw Error('No suitable zaakconnector found');
         }
       } else {
-        response = await listZakenRequest(session, config.zaken, config.inzendingen);
+        response = await listZakenRequest(session, config.zaakAggregator);
       }
       console.timeEnd('request');
       return response;
@@ -72,11 +73,10 @@ export async function zakenRequestHandler(
   return Response.redirect('/login');
 }
 
-async function listZakenRequest(session: Session, statuses: Zaken, inzendingen?: Inzendingen) {
+async function listZakenRequest(session: Session, aggregator: ZaakAggregator) {
   console.timeLog('request', 'Api Client init');
 
   const user = getUser(session);
-  let aggregator = zakenAggregator(inzendingen, statuses);
   const zaken = await aggregator.list(user);
   const zaakSummaries = ZaakFormatter.formatList(zaken);
 
@@ -141,21 +141,3 @@ function getUser(session: Session) {
   return user;
 }
 
-function zakenAggregator(inzendingen: Inzendingen | undefined, statuses: Zaken) {
-  let aggregator;
-  if (inzendingen) {
-    aggregator = new ZaakAggregator({
-      zaakConnectors: {
-        zaken: statuses,
-        inzendingen: inzendingen,
-      },
-    });
-  } else {
-    aggregator = new ZaakAggregator({
-      zaakConnectors: {
-        zaken: statuses,
-      },
-    });
-  };
-  return aggregator;
-}


### PR DESCRIPTION
Moves the zaakAggregator to the lambda, preparing
for removing implementation-specific config in
the handler function.

Currently there's duplication, since only the
list-endpoint uses the aggregator, the next step
is modifying the get and download functions to
use it as well.