### PR TITLE
chore: Use zaakAggregator for list and get request

### DIFF
--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -28,7 +28,17 @@ export class ZaakAggregator {
   }
 
   async get(zaakId: string, zaakConnectorId: string, user: User) {
+    if (!this.zaakConnectors[zaakConnectorId]) {
+      throw Error(`Zaakconnector with id ${zaakConnectorId} not found`);
+    }
     const zaak = await this.zaakConnectors[zaakConnectorId].get(zaakId, user);
     return zaak;
+  }
+
+  async download(zaakConnectorId: string, zaakId: string, file: string, user: User) {
+    if (!this.zaakConnectors[zaakConnectorId]) {
+      throw Error(`Zaakconnector with id ${zaakConnectorId} not found`);
+    }
+    return this.zaakConnectors[zaakConnectorId].download(zaakId, file, user);
   }
 }

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -124,8 +124,8 @@ const axiosInstance = axios.create(
 const client = new OpenZaakClient({ baseUrl, axiosInstance });
 const zaken = new Zaken(client, { zaakConnectorId: 'test' });
 const inzendingen = new Inzendingen({ baseUrl: 'https://localhost', accessKey: 'test' });
-const zaakAggregator = new ZaakAggregator({ zaakConnectors: { inzendingen, zaken } });
-const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaken } });
+const zaakAggregator = new ZaakAggregator({ zaakConnectors: { inzendingen, zaak: zaken } });
+const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaak: zaken } });
 
 describe('Request handler', () => {
   test('returns 200 for person', async () => {

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -47,7 +47,7 @@ export async function handler(event: any, _context: any):Promise<ApiGatewayV2Res
     const secrets = await initPromise;
     const zaakAggregator = new ZaakAggregator({
       zaakConnectors: {
-        zaken: await sharedZaken(secrets.vipSecret),
+        zaak: await sharedZaken(secrets.vipSecret),
       },
     });
     const submissions = inzendingen(secrets.submissionstorageSecret);


### PR DESCRIPTION
Move more functionality via the zaakAggregator, so we can start to take out implementation-specific
configuration code.