### PR TITLE
chore: Use zaakAggregator for list and get request (#416)

### DIFF
--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -130,7 +130,7 @@ const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaak: zaken }
 describe('Request handler', () => {
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, inzendingen, zaakAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -155,7 +155,7 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator });
     expect(result.statusCode).toBe(200);
   });
 });
@@ -164,7 +164,7 @@ describe('Request handler', () => {
 describe('Request handler single zaak', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test', zaakConnectorId: 'zaak' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', zaakConnectorId: 'zaak' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -2,14 +2,11 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
-import { Inzendingen } from './Inzendingen';
-import { Taken } from './Taken';
 import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
 import { Organisation, Person, User } from './User';
 import { ZaakAggregator } from './ZaakAggregator';
 import { ZaakFormatter } from './ZaakFormatter';
-import { Zaken } from './Zaken';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
 
@@ -17,12 +14,9 @@ export async function zakenRequestHandler(
   cookies: string,
   dynamoDBClient: DynamoDBClient,
   config: {
-    zaken: Zaken;
-    inzendingen?: Inzendingen;
     zaakAggregator: ZaakAggregator;
     zaak?: string;
     file?: string;
-    takenSecret?: string;
     zaakConnectorId?: string;
   }) {
   console.debug('config, ', config);
@@ -32,10 +26,6 @@ export async function zakenRequestHandler(
 
   let session = new Session(cookies, dynamoDBClient);
   await session.init();
-
-  if (config.takenSecret) {
-    config.zaken.setTaken(Taken.withApiKey(config.takenSecret));
-  }
 
   console.timeLog('request', 'init session');
   if (session.isLoggedIn() == true) {


### PR DESCRIPTION
Move more functionality via the zaakAggregator, so we can start to take out implementation-specific
configuration code.
