### PR TITLE
chore: refactor zakenrequesthandler

### DIFF
--- a/src/app/zaken/User.ts
+++ b/src/app/zaken/User.ts
@@ -1,3 +1,4 @@
+import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
 
 /**
@@ -40,4 +41,16 @@ export class Organisation implements User {
     this.identifier = kvk;
     this.userName = userName;
   }
+}
+
+
+export function UserFromSession(session: Session): User {
+  const userType = session.getValue('user_type');
+  let user: User;
+  if (userType == 'organisation') {
+    user = new Organisation(session.getValue('identifier'), session.getValue('username'));
+  } else {
+    user = new Person(new Bsn(session.getValue('identifier')), session.getValue('username'));
+  }
+  return user;
 }

--- a/src/app/zaken/User.ts
+++ b/src/app/zaken/User.ts
@@ -8,6 +8,7 @@ import { Bsn } from '@gemeentenijmegen/utils';
 export interface User {
   identifier: string;
   type: 'person' | 'organisation';
+  userName?: string;
 }
 
 /**
@@ -18,9 +19,10 @@ export class Person implements User {
   identifier: string;
   userName?: string;
   type: 'person' | 'organisation' = 'person';
-  constructor(bsn: Bsn) {
+  constructor(bsn: Bsn, userName?: string) {
     this.bsn = bsn;
     this.identifier = bsn.bsn;
+    this.userName = userName;
   }
 }
 
@@ -31,9 +33,11 @@ export class Organisation implements User {
   kvk: string;
   identifier: string;
   type: 'person' | 'organisation' = 'organisation';
+  userName?: string;
 
-  constructor(kvk: string) {
+  constructor(kvk: string, userName?: string) {
     this.kvk = kvk;
     this.identifier = kvk;
+    this.userName = userName;
   }
 }

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -36,9 +36,11 @@ export class ZaakAggregator {
   }
 
   async download(zaakConnectorId: string, zaakId: string, file: string, user: User) {
+    console.debug('zaakConnectorId', zaakConnectorId);
     if (!this.zaakConnectors[zaakConnectorId]) {
       throw Error(`Zaakconnector with id ${zaakConnectorId} not found`);
     }
+    console.debug(this.zaakConnectors[zaakConnectorId]);
     return this.zaakConnectors[zaakConnectorId].download(zaakId, file, user);
   }
 }

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -10,7 +10,7 @@ import { OpenZaakClient } from '../OpenZaakClient';
 import { ZaakAggregator } from '../ZaakAggregator';
 import { ZaakSummary } from '../ZaakConnector';
 import { Zaken } from '../Zaken';
-import { ZaakRequestHandler } from '../zakenRequestHandler';
+import { ZakenRequestHandler } from '../zakenRequestHandler';
 dotenv.config();
 
 const sampleDate = new Date();
@@ -132,7 +132,7 @@ const inzendingen = new Inzendingen({ baseUrl: 'https://localhost', accessKey: '
 const zaakAggregator = new ZaakAggregator({ zaakConnectors: { inzendingen, zaak: zaken } });
 
 describe('Request handler class', () => {
-  const handler = new ZaakRequestHandler(zaakAggregator, new DynamoDBClient({ region: process.env.AWS_REGION }));
+  const handler = new ZakenRequestHandler(zaakAggregator, new DynamoDBClient({ region: process.env.AWS_REGION }));
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
     const result = await handler.handleRequest('session=12345');

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -130,7 +130,7 @@ const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaak: zaken }
 describe('Request handler', () => {
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, inzendingen, zaakAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -155,7 +155,7 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator });
     expect(result.statusCode).toBe(200);
   });
 });
@@ -164,7 +164,7 @@ describe('Request handler', () => {
 describe('Request handler single zaak', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test', zaakConnectorId: 'zaak' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', zaakConnectorId: 'zaak' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -7,12 +7,13 @@ import { OpenZaakClient } from './OpenZaakClient';
 import { Taken } from './Taken';
 import { ZaakAggregator } from './ZaakAggregator';
 import { Zaken } from './Zaken';
-import { zakenRequestHandler } from './zakenRequestHandler';
+import { ZaakRequestHandler } from './zakenRequestHandler';
 
 const dynamoDBClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 
 let openZaakClient: OpenZaakClient | false;
 let zaken: Zaken | false;
+let sharedRequestHandler: ZaakRequestHandler;
 
 async function initSecret() {
   if (!process.env.VIP_JWT_SECRET_ARN || !process.env.VIP_TAKEN_SECRET_ARN || !process.env.SUBMISSIONSTORAGE_SECRET_ARN) {
@@ -23,6 +24,23 @@ async function initSecret() {
     takenSecret: await AWS.getSecret(process.env.VIP_TAKEN_SECRET_ARN),
     submissionstorageSecret: await AWS.getSecret(process.env.SUBMISSIONSTORAGE_SECRET_ARN),
   };
+}
+
+async function sharedZakenRequestHandler() {
+  if (!sharedRequestHandler) {
+    const secrets = await initPromise;
+    const zaakAggregator = new ZaakAggregator({
+      zaakConnectors: {
+        zaak: await sharedZaken(secrets.vipSecret, secrets.takenSecret),
+      },
+    });
+    const submissions = inzendingen(secrets.submissionstorageSecret);
+    if (submissions) {
+      zaakAggregator.addConnector('inzendingen', submissions);
+    }
+    sharedRequestHandler = new ZaakRequestHandler(zaakAggregator, dynamoDBClient);
+  }
+  return sharedRequestHandler;
 }
 
 const initPromise = initSecret();
@@ -45,23 +63,8 @@ export async function handler(event: any, _context: any):Promise<ApiGatewayV2Res
   }
   try {
     const params = parseEvent(event);
-    const secrets = await initPromise;
-    const zaakAggregator = new ZaakAggregator({
-      zaakConnectors: {
-        zaak: await sharedZaken(secrets.vipSecret, secrets.takenSecret),
-      },
-    });
-    const submissions = inzendingen(secrets.submissionstorageSecret);
-    if (submissions) {
-      zaakAggregator.addConnector('inzendingen', submissions);
-    }
-    inzendingen:
-    return await zakenRequestHandler(params.cookies, dynamoDBClient, {
-      zaakAggregator,
-      zaak: params.zaakId,
-      zaakConnectorId: params.zaakConnectorId,
-      file: params.file,
-    });
+    const requestHandler = await sharedZakenRequestHandler();
+    return await requestHandler.handleRequest(params.cookies, params.zaakConnectorId, params.zaakId, params.file);
   } catch (err) {
     console.debug(err);
     return Response.error(500);

--- a/src/app/zaken/zaken.lambda.ts
+++ b/src/app/zaken/zaken.lambda.ts
@@ -7,13 +7,13 @@ import { OpenZaakClient } from './OpenZaakClient';
 import { Taken } from './Taken';
 import { ZaakAggregator } from './ZaakAggregator';
 import { Zaken } from './Zaken';
-import { ZaakRequestHandler } from './zakenRequestHandler';
+import { ZakenRequestHandler } from './zakenRequestHandler';
 
 const dynamoDBClient = new DynamoDBClient({ region: process.env.AWS_REGION });
 
 let openZaakClient: OpenZaakClient | false;
 let zaken: Zaken | false;
-let sharedRequestHandler: ZaakRequestHandler;
+let sharedRequestHandler: ZakenRequestHandler;
 
 async function initSecret() {
   if (!process.env.VIP_JWT_SECRET_ARN || !process.env.VIP_TAKEN_SECRET_ARN || !process.env.SUBMISSIONSTORAGE_SECRET_ARN) {
@@ -38,7 +38,7 @@ async function sharedZakenRequestHandler() {
     if (submissions) {
       zaakAggregator.addConnector('inzendingen', submissions);
     }
-    sharedRequestHandler = new ZaakRequestHandler(zaakAggregator, dynamoDBClient);
+    sharedRequestHandler = new ZakenRequestHandler(zaakAggregator, dynamoDBClient);
   }
   return sharedRequestHandler;
 }

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -2,14 +2,11 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
-import { Inzendingen } from './Inzendingen';
-import { Taken } from './Taken';
 import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
 import { Organisation, Person, User } from './User';
 import { ZaakAggregator } from './ZaakAggregator';
 import { ZaakFormatter } from './ZaakFormatter';
-import { Zaken } from './Zaken';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
 
@@ -17,12 +14,9 @@ export async function zakenRequestHandler(
   cookies: string,
   dynamoDBClient: DynamoDBClient,
   config: {
-    zaken: Zaken;
-    inzendingen?: Inzendingen;
     zaakAggregator: ZaakAggregator;
     zaak?: string;
     file?: string;
-    takenSecret?: string;
     zaakConnectorId?: string;
   }) {
   console.debug('config, ', config);
@@ -32,10 +26,6 @@ export async function zakenRequestHandler(
 
   let session = new Session(cookies, dynamoDBClient);
   await session.init();
-
-  if (config.takenSecret) {
-    config.zaken.setTaken(Taken.withApiKey(config.takenSecret));
-  }
 
   console.timeLog('request', 'init session');
   if (session.isLoggedIn() == true) {

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -10,111 +10,87 @@ import { ZaakFormatter } from './ZaakFormatter';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
 
-export async function zakenRequestHandler(
-  cookies: string,
-  dynamoDBClient: DynamoDBClient,
-  config: {
-    zaakAggregator: ZaakAggregator;
-    zaak?: string;
-    file?: string;
-    zaakConnectorId?: string;
-  }) {
-  console.debug('config, ', config);
-  console.time('request');
-  console.timeLog('request', 'start request');
-  console.timeLog('request', 'finished init');
-
-  let session = new Session(cookies, dynamoDBClient);
-  await session.init();
-
-  console.timeLog('request', 'init session');
-  if (session.isLoggedIn() == true) {
-    try {
-      let response;
-      if (config.zaak) {
-        const zaakConnectorId = config.zaakConnectorId ?? '';
-        if (['inzendingen', 'zaak'].includes(zaakConnectorId as string)) {
-          if (config.file) {
-            response = await downloadRequest(session, config.zaakAggregator, zaakConnectorId, config.zaak, config.file);
-          } else {
-            response = await singleZaakRequest(session, config.zaakAggregator, zaakConnectorId, config.zaak);
-          }
-        } else {
-          throw Error('No suitable zaakconnector found');
-        }
-      } else {
-        response = await listZakenRequest(session, config.zaakAggregator);
-      }
-      console.timeEnd('request');
-      return response;
-    } catch (error: any) {
-      console.error(error);
-      return Response.error(500);
-    }
+export class ZaakRequestHandler {
+  private zaakAggregator: ZaakAggregator;
+  private dynamoDBClient: DynamoDBClient;
+  constructor(zaakAggregator: ZaakAggregator, dynamoDBClient: DynamoDBClient) {
+    this.zaakAggregator = zaakAggregator;
+    this.dynamoDBClient = dynamoDBClient;
   }
 
-  console.timeEnd('request');
-  return Response.redirect('/login');
-}
+  async handleRequest(cookies: string, zaakConnectorId?: string, zaak?: string, file?: string ) {
+    // do session stuff here
+    let session = new Session(cookies, this.dynamoDBClient);
+    await session.init();
+    if (session.isLoggedIn() != true) {
+      return Response.redirect('/login');
+    }
 
-async function listZakenRequest(session: Session, aggregator: ZaakAggregator) {
-  console.timeLog('request', 'Api Client init');
+    if (!zaak) {
+      return this.list(session);
+    }
 
-  const user = getUser(session);
-  const zaken = await aggregator.list(user);
-  const zaakSummaries = ZaakFormatter.formatList(zaken);
+    if (zaak && zaakConnectorId && !file) {
+      return this.get(zaakConnectorId, zaak, session);
+    }
 
-  const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
-  let data = {
-    volledigenaam: session.getValue('username'),
-    title: 'Lopende zaken',
-    shownav: true,
-    nav: navigation.items,
-    zaken: zaakSummaries,
-  };
-  console.debug('data', JSON.stringify(data.zaken));
-  // render page
-  const html = await render(data, zakenTemplate.default);
-  return Response.html(html, 200, session.getCookie());
-}
+    if (zaak && zaakConnectorId && file) {
+      return this.download(zaakConnectorId, zaak, file, session);
+    }
+    return Response.error(400);
+  }
 
-async function singleZaakRequest(
-  session: Session,
-  zaakAggregator: ZaakAggregator,
-  zaakConnectorId: string,
-  zaakId: string) {
+  async list(session: Session) {
+    const user = getUser(session);
+    console.timeLog('request', 'Api Client init');
 
-  console.timeLog('request', 'Api Client init');
-
-  const user = getUser(session);
-  const zaak = await zaakAggregator.get(zaakId, zaakConnectorId, user);
-  console.timeLog('request', 'zaak received');
-  if (zaak) {
-    const formattedZaak = ZaakFormatter.formatZaak(zaak);
+    const zaken = await this.zaakAggregator.list(user);
+    const zaakSummaries = ZaakFormatter.formatList(zaken);
 
     const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
     let data = {
-      volledigenaam: session.getValue('username'),
-      title: 'Zaak',
+      volledigenaam: user.userName,
+      title: 'Lopende zaken',
       shownav: true,
       nav: navigation.items,
-      zaak: formattedZaak,
+      zaken: zaakSummaries,
     };
+    console.debug('data', JSON.stringify(data.zaken));
     // render page
-    const html = await render(data, zaakTemplate.default);
+    const html = await render(data, zakenTemplate.default);
     return Response.html(html, 200, session.getCookie());
-  } else {
-    return Response.error(404);
   }
-}
 
-async function downloadRequest(session: Session, zaakAggregator: ZaakAggregator, zaakConnectorId: string, zaakId: string, file: string) {
-  const user = getUser(session);
-  const response = await zaakAggregator.download(zaakConnectorId, zaakId, file, user);
-  if (response) {
-    return Response.redirect(response.downloadUrl);
-  } else {
-    return Response.error(404);
+  async get(zaakConnectorId: string, zaakId: string, session: Session) {
+    const user = getUser(session);
+    const zaak = await this.zaakAggregator.get(zaakId, zaakConnectorId, user);
+    if (zaak) {
+      const formattedZaak = ZaakFormatter.formatZaak(zaak);
+
+      const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
+      let data = {
+        volledigenaam: session.getValue('username'),
+        title: 'Zaak',
+        shownav: true,
+        nav: navigation.items,
+        zaak: formattedZaak,
+      };
+      // render page
+      const html = await render(data, zaakTemplate.default);
+      return Response.html(html, 200, session.getCookie());
+    } else {
+      return Response.error(404);
+    }
+  }
+
+  async download(zaakConnectorId: string, zaakId: string, file: string, session: Session) {
+    const user = getUser(session);
+    const response = await this.zaakAggregator.download(zaakConnectorId, zaakId, file, user);
+    if (response) {
+      return Response.redirect(response.downloadUrl);
+    } else {
+      return Response.error(404);
+    }
   }
 }
 
@@ -122,9 +98,9 @@ function getUser(session: Session) {
   const userType = session.getValue('user_type');
   let user: User;
   if (userType == 'organisation') {
-    user = new Organisation(session.getValue('identifier'));
+    user = new Organisation(session.getValue('identifier'), session.getValue('username'));
   } else {
-    user = new Person(new Bsn(session.getValue('identifier')));
+    user = new Person(new Bsn(session.getValue('identifier')), session.getValue('username'));
   }
   return user;
 }


### PR DESCRIPTION
- All calls now use the aggregator, so directly providing Zaken or
Inzendingen is no longer required.
- Use a shared class instance with
provided params, instead of providing all params
with each request.