### PR TITLE
chore: refactor zakenrequesthandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.114.1-alpha.0",
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.114.1-alpha.0",
     "@aws-sdk/client-dynamodb": "^3.540.0",
-    "@aws-sdk/client-secrets-manager": "^3.540.0",
+    "@aws-sdk/client-secrets-manager": "^3.543.0",
     "@aws-solutions-constructs/aws-lambda-dynamodb": "^2.54.0",
     "@gemeentenijmegen/apiclient": "^0.0.12",
     "@gemeentenijmegen/apigateway-http": "^0.0.8",

--- a/src/app/zaken/User.ts
+++ b/src/app/zaken/User.ts
@@ -1,3 +1,4 @@
+import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
 
 /**
@@ -8,6 +9,7 @@ import { Bsn } from '@gemeentenijmegen/utils';
 export interface User {
   identifier: string;
   type: 'person' | 'organisation';
+  userName?: string;
 }
 
 /**
@@ -18,9 +20,10 @@ export class Person implements User {
   identifier: string;
   userName?: string;
   type: 'person' | 'organisation' = 'person';
-  constructor(bsn: Bsn) {
+  constructor(bsn: Bsn, userName?: string) {
     this.bsn = bsn;
     this.identifier = bsn.bsn;
+    this.userName = userName;
   }
 }
 
@@ -31,9 +34,23 @@ export class Organisation implements User {
   kvk: string;
   identifier: string;
   type: 'person' | 'organisation' = 'organisation';
+  userName?: string;
 
-  constructor(kvk: string) {
+  constructor(kvk: string, userName?: string) {
     this.kvk = kvk;
     this.identifier = kvk;
+    this.userName = userName;
   }
+}
+
+
+export function UserFromSession(session: Session): User {
+  const userType = session.getValue('user_type');
+  let user: User;
+  if (userType == 'organisation') {
+    user = new Organisation(session.getValue('identifier'), session.getValue('username'));
+  } else {
+    user = new Person(new Bsn(session.getValue('identifier')), session.getValue('username'));
+  }
+  return user;
 }

--- a/src/app/zaken/ZaakAggregator.ts
+++ b/src/app/zaken/ZaakAggregator.ts
@@ -36,9 +36,11 @@ export class ZaakAggregator {
   }
 
   async download(zaakConnectorId: string, zaakId: string, file: string, user: User) {
+    console.debug('zaakConnectorId', zaakConnectorId);
     if (!this.zaakConnectors[zaakConnectorId]) {
       throw Error(`Zaakconnector with id ${zaakConnectorId} not found`);
     }
+    console.debug(this.zaakConnectors[zaakConnectorId]);
     return this.zaakConnectors[zaakConnectorId].download(zaakId, file, user);
   }
 }

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -130,7 +130,7 @@ const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaak: zaken }
 describe('Request handler', () => {
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, inzendingen, zaakAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -155,7 +155,7 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, takenSecret: 'test' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator });
     expect(result.statusCode).toBe(200);
   });
 });
@@ -164,7 +164,7 @@ describe('Request handler', () => {
 describe('Request handler single zaak', () => {
   test('returns 200', async () => {
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaken, zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', takenSecret: 'test', zaakConnectorId: 'zaak' });
+    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', zaakConnectorId: 'zaak' });
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {

--- a/src/app/zaken/tests/requestHandler.test.ts
+++ b/src/app/zaken/tests/requestHandler.test.ts
@@ -10,7 +10,7 @@ import { OpenZaakClient } from '../OpenZaakClient';
 import { ZaakAggregator } from '../ZaakAggregator';
 import { ZaakSummary } from '../ZaakConnector';
 import { Zaken } from '../Zaken';
-import { zakenRequestHandler } from '../zakenRequestHandler';
+import { ZakenRequestHandler } from '../zakenRequestHandler';
 dotenv.config();
 
 const sampleDate = new Date();
@@ -58,6 +58,10 @@ const mockedInzendingenList: ZaakSummary[] = [
   },
 ];
 
+const mockedDownload = {
+  downloadUrl: 'https://somebucket.s3.eu-central-1.amazonaws.com/APV1.234/APV1.234.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=<SOMESTRING>%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20240305T135245Z&X-Amz-Expires=5&X-Amz-Security-Token=<REALLYLONGSTRING>X-Amz-Signature=<SIGNATURE>&X-Amz-SignedHeaders=host&x-id=GetObject',
+};
+
 jest.mock('../Zaken', () => {
   return {
     Zaken: jest.fn(() => {
@@ -78,6 +82,7 @@ jest.mock('../Inzendingen', () => {
       return {
         list: jest.fn().mockResolvedValue(mockedInzendingenList),
         get: jest.fn().mockResolvedValue(mockedZaak),
+        download: jest.fn().mockResolvedValue(mockedDownload),
       };
     }),
   };
@@ -125,12 +130,12 @@ const client = new OpenZaakClient({ baseUrl, axiosInstance });
 const zaken = new Zaken(client, { zaakConnectorId: 'test' });
 const inzendingen = new Inzendingen({ baseUrl: 'https://localhost', accessKey: 'test' });
 const zaakAggregator = new ZaakAggregator({ zaakConnectors: { inzendingen, zaak: zaken } });
-const zakenOnlyAggregator = new ZaakAggregator({ zaakConnectors: { zaak: zaken } });
 
-describe('Request handler', () => {
+describe('Request handler class', () => {
+  const handler = new ZakenRequestHandler(zaakAggregator, new DynamoDBClient({ region: process.env.AWS_REGION }));
   test('returns 200 for person', async () => {
     console.debug('inzendingen in test', inzendingen);
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator });
+    const result = await handler.handleRequest('session=12345');
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -155,16 +160,12 @@ describe('Request handler', () => {
     };
     ddbMock.on(GetItemCommand).resolves(getItemOutputForOrganisation);
 
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator });
+    const result = await handler.handleRequest('session=12345');
     expect(result.statusCode).toBe(200);
   });
-});
 
-
-describe('Request handler single zaak', () => {
-  test('returns 200', async () => {
-
-    const result = await zakenRequestHandler('session=12345', new DynamoDBClient({ region: process.env.AWS_REGION }), { zaakAggregator: zakenOnlyAggregator, zaak: '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', zaakConnectorId: 'zaak' });
+  test('returns 200 for single zaak', async () => {
+    const result = await handler.handleRequest('session=12345', 'zaak', '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886');
     expect(result.statusCode).toBe(200);
     if (result.body) {
       try {
@@ -175,4 +176,9 @@ describe('Request handler single zaak', () => {
     }
   });
 
+  test('returns link for download', async () => {
+    const result = await handler.handleRequest('session=12345', 'inzendingen', '5b1c4f8f-8c62-41ac-a3a0-e2ac08b6e886', 'test.png');
+    expect(result.statusCode).toBe(302);
+    expect(result.headers).toHaveProperty('Location');
+  });
 });

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -2,14 +2,11 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
 import { Bsn } from '@gemeentenijmegen/utils';
-import { Inzendingen } from './Inzendingen';
-import { Taken } from './Taken';
 import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
 import { Organisation, Person, User } from './User';
 import { ZaakAggregator } from './ZaakAggregator';
 import { ZaakFormatter } from './ZaakFormatter';
-import { Zaken } from './Zaken';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
 
@@ -17,12 +14,9 @@ export async function zakenRequestHandler(
   cookies: string,
   dynamoDBClient: DynamoDBClient,
   config: {
-    zaken: Zaken;
-    inzendingen?: Inzendingen;
     zaakAggregator: ZaakAggregator;
     zaak?: string;
     file?: string;
-    takenSecret?: string;
     zaakConnectorId?: string;
   }) {
   console.debug('config, ', config);
@@ -32,10 +26,6 @@ export async function zakenRequestHandler(
 
   let session = new Session(cookies, dynamoDBClient);
   await session.init();
-
-  if (config.takenSecret) {
-    config.zaken.setTaken(Taken.withApiKey(config.takenSecret));
-  }
 
   console.timeLog('request', 'init session');
   if (session.isLoggedIn() == true) {

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -1,131 +1,95 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { Response } from '@gemeentenijmegen/apigateway-http/lib/V2/Response';
 import { Session } from '@gemeentenijmegen/session';
-import { Bsn } from '@gemeentenijmegen/utils';
 import * as zaakTemplate from './templates/zaak.mustache';
 import * as zakenTemplate from './templates/zaken.mustache';
-import { Organisation, Person, User } from './User';
+import { UserFromSession } from './User';
 import { ZaakAggregator } from './ZaakAggregator';
 import { ZaakFormatter } from './ZaakFormatter';
 import { Navigation } from '../../shared/Navigation';
 import { render } from '../../shared/render';
 
-export async function zakenRequestHandler(
-  cookies: string,
-  dynamoDBClient: DynamoDBClient,
-  config: {
-    zaakAggregator: ZaakAggregator;
-    zaak?: string;
-    file?: string;
-    zaakConnectorId?: string;
-  }) {
-  console.debug('config, ', config);
-  console.time('request');
-  console.timeLog('request', 'start request');
-  console.timeLog('request', 'finished init');
-
-  let session = new Session(cookies, dynamoDBClient);
-  await session.init();
-
-  console.timeLog('request', 'init session');
-  if (session.isLoggedIn() == true) {
-    try {
-      let response;
-      if (config.zaak) {
-        const zaakConnectorId = config.zaakConnectorId ?? '';
-        if (['inzendingen', 'zaak'].includes(zaakConnectorId as string)) {
-          if (config.file) {
-            response = await downloadRequest(session, config.zaakAggregator, zaakConnectorId, config.zaak, config.file);
-          } else {
-            response = await singleZaakRequest(session, config.zaakAggregator, zaakConnectorId, config.zaak);
-          }
-        } else {
-          throw Error('No suitable zaakconnector found');
-        }
-      } else {
-        response = await listZakenRequest(session, config.zaakAggregator);
-      }
-      console.timeEnd('request');
-      return response;
-    } catch (error: any) {
-      console.error(error);
-      return Response.error(500);
-    }
+export class ZakenRequestHandler {
+  private zaakAggregator: ZaakAggregator;
+  private dynamoDBClient: DynamoDBClient;
+  constructor(zaakAggregator: ZaakAggregator, dynamoDBClient: DynamoDBClient) {
+    this.zaakAggregator = zaakAggregator;
+    this.dynamoDBClient = dynamoDBClient;
   }
 
-  console.timeEnd('request');
-  return Response.redirect('/login');
-}
+  async handleRequest(cookies: string, zaakConnectorId?: string, zaak?: string, file?: string ) {
+    // do session stuff here
+    let session = new Session(cookies, this.dynamoDBClient);
+    await session.init();
+    if (session.isLoggedIn() != true) {
+      return Response.redirect('/login');
+    }
 
-async function listZakenRequest(session: Session, aggregator: ZaakAggregator) {
-  console.timeLog('request', 'Api Client init');
+    if (!zaak) {
+      return this.list(session);
+    }
 
-  const user = getUser(session);
-  const zaken = await aggregator.list(user);
-  const zaakSummaries = ZaakFormatter.formatList(zaken);
+    if (zaak && zaakConnectorId && !file) {
+      return this.get(zaakConnectorId, zaak, session);
+    }
 
-  const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
-  let data = {
-    volledigenaam: session.getValue('username'),
-    title: 'Lopende zaken',
-    shownav: true,
-    nav: navigation.items,
-    zaken: zaakSummaries,
-  };
-  console.debug('data', JSON.stringify(data.zaken));
-  // render page
-  const html = await render(data, zakenTemplate.default);
-  return Response.html(html, 200, session.getCookie());
-}
+    if (zaak && zaakConnectorId && file) {
+      return this.download(zaakConnectorId, zaak, file, session);
+    }
+    return Response.error(400);
+  }
 
-async function singleZaakRequest(
-  session: Session,
-  zaakAggregator: ZaakAggregator,
-  zaakConnectorId: string,
-  zaakId: string) {
+  async list(session: Session) {
+    const user = UserFromSession(session);
+    console.timeLog('request', 'Api Client init');
 
-  console.timeLog('request', 'Api Client init');
-
-  const user = getUser(session);
-  const zaak = await zaakAggregator.get(zaakId, zaakConnectorId, user);
-  console.timeLog('request', 'zaak received');
-  if (zaak) {
-    const formattedZaak = ZaakFormatter.formatZaak(zaak);
+    const zaken = await this.zaakAggregator.list(user);
+    const zaakSummaries = ZaakFormatter.formatList(zaken);
 
     const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
     let data = {
-      volledigenaam: session.getValue('username'),
-      title: 'Zaak',
+      volledigenaam: user.userName,
+      title: 'Lopende zaken',
       shownav: true,
       nav: navigation.items,
-      zaak: formattedZaak,
+      zaken: zaakSummaries,
     };
+    console.debug('data', JSON.stringify(data.zaken));
     // render page
-    const html = await render(data, zaakTemplate.default);
+    const html = await render(data, zakenTemplate.default);
     return Response.html(html, 200, session.getCookie());
-  } else {
-    return Response.error(404);
   }
-}
 
-async function downloadRequest(session: Session, zaakAggregator: ZaakAggregator, zaakConnectorId: string, zaakId: string, file: string) {
-  const user = getUser(session);
-  const response = await zaakAggregator.download(zaakConnectorId, zaakId, file, user);
-  if (response) {
-    return Response.redirect(response.downloadUrl);
-  } else {
-    return Response.error(404);
-  }
-}
+  async get(zaakConnectorId: string, zaakId: string, session: Session) {
+    const user = UserFromSession(session);
+    const zaak = await this.zaakAggregator.get(zaakId, zaakConnectorId, user);
+    if (zaak) {
+      const formattedZaak = ZaakFormatter.formatZaak(zaak);
 
-function getUser(session: Session) {
-  const userType = session.getValue('user_type');
-  let user: User;
-  if (userType == 'organisation') {
-    user = new Organisation(session.getValue('identifier'));
-  } else {
-    user = new Person(new Bsn(session.getValue('identifier')));
+      const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
+      let data = {
+        volledigenaam: session.getValue('username'),
+        title: 'Zaak',
+        shownav: true,
+        nav: navigation.items,
+        zaak: formattedZaak,
+      };
+      // render page
+      const html = await render(data, zaakTemplate.default);
+      return Response.html(html, 200, session.getCookie());
+    } else {
+      return Response.error(404);
+    }
   }
-  return user;
+
+  async download(zaakConnectorId: string, zaakId: string, file: string, session: Session) {
+    const user = UserFromSession(session);
+    const response = await this.zaakAggregator.download(zaakConnectorId, zaakId, file, user);
+    if (response) {
+      return Response.redirect(response.downloadUrl);
+    } else {
+      return Response.error(404);
+    }
+  }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,10 +149,10 @@
     tslib "^2.6.2"
     uuid "^9.0.1"
 
-"@aws-sdk/client-secrets-manager@^3.509.0", "@aws-sdk/client-secrets-manager@^3.540.0":
-  version "3.540.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.540.0.tgz#b5be29da151cb088132b8c8bce26fadd094065d0"
-  integrity sha512-bobnFYxHR1RLqqQCQ0EETFETUEcLKSMeEgmDU7xsNPmzvx/3iWNMbXsMvikRrkuWFcsPIr2ofEGU2epvSHrTuA==
+"@aws-sdk/client-secrets-manager@^3.509.0", "@aws-sdk/client-secrets-manager@^3.543.0":
+  version "3.543.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.543.0.tgz#7c0695f53081c61c879aefa19ccbb9d0feebde53"
+  integrity sha512-aTSsCv9UbKLilOmU3jeeu0wL9b96Uf8aZCpb/kO59dZ6a10/TB/l1VbsJjgFTkz4II4CaGnZF9Cy7PlRoVLr/g==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
@@ -1897,9 +1897,9 @@
     tslib "^2.6.2"
 
 "@tsconfig/node10@^1.0.7":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.10.tgz#b7ebd3adfa7750628d100594f6726b054d2c33b2"
-  integrity sha512-PiaIWIoPvO6qm6t114ropMCagj6YAF24j9OkCA2mJDXFnlionEwhsBCJ8yek4aib575BI3OkART/90WsgHgLWw==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
@@ -3139,9 +3139,9 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.717"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz#99db370cae8cd090d5b01f8748e9ad369924d0f8"
-  integrity sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==
+  version "1.4.719"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.719.tgz#22a94ce7a5150511ba88e900836039e159efe22c"
+  integrity sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==
 
 emittery@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
* chore: Remove zaken and inzendingen from handler

All calls now use the aggregator, so directly providing Zaken or
Inzendingen is no longer required.

* chore: Refactor zakenRequestHandler

Refactor to use a shared class instance with
provided params, instead of providing all params
with each request.

* chore: Rename handler class, move user helper

Moves the user helper function to the User file,
renames requesthandler.