### PR TITLE
fix: Typo in text

### DIFF
--- a/src/app/zaken/Inzendingen.ts
+++ b/src/app/zaken/Inzendingen.ts
@@ -122,7 +122,7 @@ export class Inzendingen implements ZaakConnector {
       internal_id: `inzendingen/${inzending.key}`,
       registratiedatum: inzending?.dateSubmitted,
       zaak_type: inzending.formTitle,
-      status: 'ontvangen',
+      status: 'Ontvangen',
     };
   }
 
@@ -133,7 +133,7 @@ export class Inzendingen implements ZaakConnector {
       key: inzending.key,
       zaak_type: inzending.formTitle,
       registratiedatum: inzending.dateSubmitted,
-      status: 'ontvangen',
+      status: 'Ontvangen',
       documenten: inzending.attachments.map((attachment) => {
         return {
           url: `attachments/${attachment}`,

--- a/src/app/zaken/ZaakFormatter.ts
+++ b/src/app/zaken/ZaakFormatter.ts
@@ -1,7 +1,7 @@
 import { SingleZaak, ZaakSummary } from './ZaakConnector';
 
 export class ZaakFormatter {
-  static formatList(zaken: ZaakSummary[]) {
+  formatList(zaken: ZaakSummary[]) {
     const sorted = zaken
       .sort((a, b) => a.registratiedatum < b.registratiedatum ? 1 : -1)
       .map(zaak => this.formatZaakSummary(zaak));
@@ -11,7 +11,7 @@ export class ZaakFormatter {
     };
   }
 
-  static formatZaakSummary(zaak: ZaakSummary) {
+  formatZaakSummary(zaak: ZaakSummary) {
     return {
       ...zaak,
       registratiedatum: this.humanDate(zaak.registratiedatum),
@@ -21,7 +21,7 @@ export class ZaakFormatter {
     };
   }
 
-  static formatZaak(zaak: SingleZaak) {
+  formatZaak(zaak: SingleZaak) {
     return {
       ...zaak,
       registratiedatum: this.humanDate(zaak.registratiedatum),
@@ -40,12 +40,12 @@ export class ZaakFormatter {
   /**
    * Convert ISO 8601 datestring to something formatted like '12 september 2023'
    */
-  private static humanDate(date: Date | undefined) {
+  private humanDate(date: Date | undefined) {
     if (!date) { return; }
     return date.toLocaleDateString('nl-NL', { year: 'numeric', month: 'long', day: 'numeric' });
   }
 
-  private static sortDocuments(document_a: any, document_b: any) {
+  private sortDocuments(document_a: any, document_b: any) {
     if (document_a.sort_order || document_b.sort_order) {
       console.debug('sorting by order');
       return document_a.sort_order > document_b.sort_order ? 1 : -1;

--- a/src/app/zaken/templates/zaak.mustache
+++ b/src/app/zaken/templates/zaak.mustache
@@ -17,7 +17,7 @@
         <div class="col-lg-9 col-md-12">
             {{#zaak}}
                 <h1>{{zaak_type}}</h1>
-                <p class="lead">Uw aanvraag is op dit moment in de fase: <strong>{{status}}</strong>. {{#verwachtte_einddatum}}Verwachtte einddatum: <strong>{{verwachtte_einddatum}}</strong>.{{/verwachtte_einddatum}}</p>
+                <p class="lead">Uw aanvraag is op dit moment in de fase: <strong>{{status}}</strong>. {{#verwachtte_einddatum}}Verwachte einddatum: <strong>{{verwachtte_einddatum}}</strong>.{{/verwachtte_einddatum}}</p>
                 {{#taken}}
                 <div class="denhaag-action">
                     <div class="denhaag-action__content">

--- a/src/app/zaken/tests/zaakformatter.test.ts
+++ b/src/app/zaken/tests/zaakformatter.test.ts
@@ -19,6 +19,6 @@ describe('Zaakformatter can format single zaak', () => {
       behandelaars: ['Piet Pietersen', 'Antoon Andriessen'],
     };
 
-    expect(ZaakFormatter.formatZaak(zaak).behandelaars).toBe('Antoon Andriessen, Piet Pietersen');
+    expect(new ZaakFormatter().formatZaak(zaak).behandelaars).toBe('Antoon Andriessen, Piet Pietersen');
   });
 });

--- a/src/app/zaken/zakenRequestHandler.ts
+++ b/src/app/zaken/zakenRequestHandler.ts
@@ -44,7 +44,7 @@ export class ZakenRequestHandler {
     console.timeLog('request', 'Api Client init');
 
     const zaken = await this.zaakAggregator.list(user);
-    const zaakSummaries = ZaakFormatter.formatList(zaken);
+    const zaakSummaries = new ZaakFormatter().formatList(zaken);
 
     const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
     let data = {
@@ -64,7 +64,7 @@ export class ZakenRequestHandler {
     const user = UserFromSession(session);
     const zaak = await this.zaakAggregator.get(zaakId, zaakConnectorId, user);
     if (zaak) {
-      const formattedZaak = ZaakFormatter.formatZaak(zaak);
+      const formattedZaak = new ZaakFormatter().formatZaak(zaak);
 
       const navigation = new Navigation(user.type, { showZaken: true, currentPath: '/zaken' });
       let data = {


### PR DESCRIPTION
- incorrect date text
- consistently uppercase status

chore: Don't use static class for formatter
